### PR TITLE
Provide a target platform for Windows

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.examples/.classpath
+++ b/plugins/org.eclipse.emf.ecoretools.ale.examples/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/releng/org.eclipse.emf.ecoretools.ale.target-platform.win32/.project
+++ b/releng/org.eclipse.emf.ecoretools.ale.target-platform.win32/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emf.ecoretools.ale.target-platform.win32</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/org.eclipse.emf.ecoretools.ale.target-platform.win32/org.eclipse.emf.ecoretools.ale.target-platform.win32.target
+++ b/releng/org.eclipse.emf.ecoretools.ale.target-platform.win32/org.eclipse.emf.ecoretools.ale.target-platform.win32.target
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Running Platform" sequenceNumber="12">
+<locations>
+	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.xtext.sdk.feature.group" version="2.14.0.v20180523-0937"/>
+		<repository location="http://download.eclipse.org/releases/photon"/>
+		<unit id="org.eclipse.emf.ecoretools.sdk.feature.group" version="3.3.0.201706121316"/>
+		<unit id="org.eclipse.emf.sdk.feature.group" version="2.14.0.v20180529-1157"/>
+		<unit id="org.eclipse.jdt.feature.group" version="3.14.0.v20180611-0500"/>
+		<unit id="org.eclipse.pde.feature.group" version="3.13.100.v20180611-0826"/>
+		<unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180611-0826"/>
+		<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806111355"/>
+		<unit id="org.eclipse.swtbot.feature.group" version="2.7.0.201806111355"/>
+		<unit id="org.eclipse.equinox.sdk.feature.group" version="3.14.0.v20180518-2029"/>
+	</location>
+</locations>
+<environment>
+<os>win32</os>
+<ws>win32</ws>
+<arch>x86_64</arch>
+<nl>en_GB</nl>
+</environment>
+</target>

--- a/releng/org.eclipse.emf.ecoretools.ale.target-platform/.project
+++ b/releng/org.eclipse.emf.ecoretools.ale.target-platform/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emf.ecoretools.ale.target-platform</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/releng/org.eclipse.emf.ecoretools.ale.target-platform/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.emf.ecoretools.ale.target-platform/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Existing target platform is tailored for Linux and cannot be used on Windows. A new one is hence introduced in the the `releng/org.eclipse.emf.ecoretools.ale.target-platform.win32` project.

Also introduces small enhancements:
- Remove nonexistent _src/_ folder from ale.examples bundle's classpath
- Make ale.target-platform an Eclipse IDE project