### PR TITLE
Improve code quality by following Sonar's advice

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/EvalEnvironment.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/EvalEnvironment.java
@@ -12,7 +12,6 @@ package org.eclipse.emf.ecoretools.ale.core.interpreter;
 
 //import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,7 +35,6 @@ import org.eclipse.acceleo.query.services.AnyServices;
 import org.eclipse.acceleo.query.services.BooleanServices;
 import org.eclipse.acceleo.query.services.CollectionServices;
 import org.eclipse.acceleo.query.services.ComparableServices;
-import org.eclipse.acceleo.query.services.EObjectServices;
 import org.eclipse.acceleo.query.services.NumberServices;
 import org.eclipse.acceleo.query.services.ResourceServices;
 import org.eclipse.acceleo.query.services.StringServices;
@@ -68,7 +66,7 @@ public class EvalEnvironment {
 	
 	/**
 	 * It contains declared EPackages & services.
-	 * Mainly used to evalute AQL expression and to resolve types
+	 * Mainly used to evaluate AQL expression and to resolve types
 	 */
 	IQueryEnvironment qryEnv;
 	
@@ -175,7 +173,7 @@ public class EvalEnvironment {
 	}
 	
 	private List<EvalBodyService> createServices(List<ModelUnit> allImplemModels) {
-		Map<Method, EvalBodyService> res = new LinkedHashMap<Method, EvalBodyService>();
+		Map<Method, EvalBodyService> res = new LinkedHashMap<>();
 		
 		/*
 		 * Create services
@@ -190,7 +188,7 @@ public class EvalEnvironment {
 				.forEach(implemOp -> res.put(implemOp,(new EvalBodyService(implemOp,this,logger))));
 			});
 		
-		List<EvalBodyService> newClassOperations = new ArrayList<EvalBodyService>();
+		List<EvalBodyService> newClassOperations = new ArrayList<>();
 		allImplemModels
 			.stream()
 			.forEach(implemModel -> {
@@ -232,7 +230,7 @@ public class EvalEnvironment {
 	
 	private Map<ExtendedClass,Integer> getPriorities(List<ExtendedClass> allCls) {
 		
-		Map<ExtendedClass,Integer> priorities = new HashMap<ExtendedClass,Integer>();
+		Map<ExtendedClass,Integer> priorities = new HashMap<>();
 		allCls
 			.stream()
 			.forEach(cls -> getPriority(cls,priorities));
@@ -311,7 +309,7 @@ public class EvalEnvironment {
 	
 	public List<ServiceCallListener> getListeners() {
 		if(listeners == null) {
-			listeners = new ArrayList<ServiceCallListener>();
+			listeners = new ArrayList<>();
 		}
 		return listeners;
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -50,10 +50,9 @@ import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableInsert;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.While;
-import org.eclipse.emf.ecoretools.ale.implementation.util.ImplementationSwitch;
 
 /**
- * This class evaluate the body of an operation.
+ * An instance of this class evaluates the body of an {@link Method operation}
  */
 public class MethodEvaluator {
 	
@@ -73,9 +72,9 @@ public class MethodEvaluator {
 	}
 	
 	public EvaluationResult eval(EObject target, Method operation, List<Object> parameters) throws CriticalFailure {
-		variablesStack = new Stack();
+		variablesStack = new Stack<>();
 		//Init variables
-		Map<String, Object> variables = new HashMap<String, Object>();
+		Map<String, Object> variables = new HashMap<>();
 		variables.put("self", target);
 		variables.put("result", null);
 		
@@ -109,7 +108,7 @@ public class MethodEvaluator {
 	}
 	
 	public Object caseBlock(Block block) throws CriticalFailure {
-		Map<String, Object> newScope = new HashMap<String, Object>();
+		Map<String, Object> newScope = new HashMap<>();
 		variablesStack.push(newScope);
 		for(Statement stmt : block.getStatements()) {
 			throwableSwitch(stmt);
@@ -148,7 +147,7 @@ public class MethodEvaluator {
 			EStructuralFeature feature = ((EObject)assigned).eClass().getEStructuralFeature(featAssign.getTargetFeature());
 			if(feature != null){
 				if(value instanceof List) {
-					BasicEList<EObject> newList = new BasicEList<EObject>((List)value);
+					BasicEList<EObject> newList = new BasicEList<>((List)value);
 					((EObject)assigned).eSet(feature, newList);
 				}
 				else {
@@ -295,7 +294,7 @@ public class MethodEvaluator {
 	
 	public Object caseForEach(ForEach forEach) throws CriticalFailure {
 		Collection<?> collection = (Collection<?>) aqlEval(forEach.getCollectionExpression());//TODO: check type
-		Map<String,Object> newScope = new HashMap<String,Object>();
+		Map<String,Object> newScope = new HashMap<>();
 		variablesStack.push(newScope);
 		for(Object elem : collection) {
 			newScope.put(forEach.getVariable(),elem);
@@ -342,7 +341,7 @@ public class MethodEvaluator {
 	 * Flatten stack
 	 */
 	private Map<String,Object> getCurrentScope() {
-		Map<String,Object> scope = new HashMap<String,Object>();
+		Map<String,Object> scope = new HashMap<>();
 		variablesStack
 		.stream()
 		.flatMap(scp -> scp.entrySet().stream())
@@ -352,7 +351,7 @@ public class MethodEvaluator {
 	}
 	
 	private Object aqlEval(Expression expression) throws CriticalFailure {
-		AstResult dummyAstResult = new AstResult(expression, new HashMap(), new HashMap(), new ArrayList(), new BasicDiagnostic());
+		AstResult dummyAstResult = new AstResult(expression, new HashMap<>(), new HashMap<>(), new ArrayList<>(), new BasicDiagnostic());
 		EvaluationResult result = aqlEngine.eval(dummyAstResult, getCurrentScope());
 		
 		if(result.getDiagnostic().getSeverity() != Diagnostic.OK){

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/AstBuilder.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/AstBuilder.java
@@ -10,17 +10,16 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.parser;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.ANTLRFileStream;
 import org.antlr.v4.runtime.ANTLRInputStream;
@@ -34,15 +33,15 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecoretools.ale.core.parser.ALEParser.RRootContext;
+import org.eclipse.emf.ecoretools.ale.core.parser.visitor.AstVisitors;
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ModelBuilder;
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult;
-import org.eclipse.emf.ecoretools.ale.core.parser.visitor.AstVisitors;
 import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
 import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 
 /**
- * This class parse ".ale" file and produce model intance of Implementation metamodel
+ * An instance of this class parses ".ale" files and produces model instances of Implementation metamodels
  */
 public class AstBuilder {
 	
@@ -55,7 +54,7 @@ public class AstBuilder {
 	
 	public List<ParseResult<ModelUnit>> parseFromInputStreams(List<InputStream> inputs) {
 		
-		List<RRootContext> parses = new ArrayList<RRootContext>();
+		List<RRootContext> parses = new ArrayList<>();
 		inputs
 			.stream()
 			.forEach(f -> {
@@ -71,8 +70,8 @@ public class AstBuilder {
 	}
 	
 	public List<ParseResult<ModelUnit>> parseFromFiles(List<String> files) {
-		List<RRootContext> parses = new ArrayList<RRootContext>();
-		Map<RRootContext,String> sourceFiles = new HashMap<RRootContext,String>(); 
+		List<RRootContext> parses = new ArrayList<>();
+		Map<RRootContext,String> sourceFiles = new HashMap<>(); 
 		files
 			.stream()
 			.forEach(f -> {
@@ -92,12 +91,12 @@ public class AstBuilder {
 	 * Transform ANTLR parse result to proper ALE model
 	 */
 	private List<ParseResult<ModelUnit>> makeModel(List<RRootContext> rawParses, Map<RRootContext,String> sourceFiles){
-		List<ParseResult<ModelUnit>> build = new ArrayList<ParseResult<ModelUnit>>();
+		List<ParseResult<ModelUnit>> build = new ArrayList<>();
 		
 		/*
 		 * Create & declare new EClasses
 		 */
-		Map<String,List<EClass>> allNewClasses = new HashMap<String,List<EClass>>();
+		Map<String,List<EClass>> allNewClasses = new HashMap<>();
 		rawParses
 			.stream()
 			.forEach(implemParse -> {
@@ -161,14 +160,14 @@ public class AstBuilder {
 		/*
     	 * Resolve extends
     	 */
-    	Map<String,List<ExtendedClass>> behaviorToClass = new HashMap<String,List<ExtendedClass>>();
-    	List<ExtendedClass> allExtensions = new ArrayList<ExtendedClass>();
+    	Map<String,List<ExtendedClass>> behaviorToClass = new HashMap<>();
+    	List<ExtendedClass> allExtensions = new ArrayList<>();
     	build
     	.stream()
     	.forEach(sem -> {
     		ModelUnit root = sem.getRoot();
     		if(root != null) {
-    			List<ExtendedClass> xtdCls =  root.getClassExtensions().stream().collect(Collectors.toList());
+    			List<ExtendedClass> xtdCls =  root.getClassExtensions().stream().collect(toList());
     			behaviorToClass.put(root.getName(), xtdCls);
     			allExtensions.addAll(xtdCls);
     		}
@@ -182,7 +181,7 @@ public class AstBuilder {
 				.stream()
 				.filter(a -> a.getSource().equals(ModelBuilder.PARSER_SOURCE))
 				.filter(a -> a.getDetails().get(ModelBuilder.PARSER_EXTENDS_KEY) != null)
-				.collect(Collectors.toList());
+				.collect(toList());
     		toResolve
 	    		.stream()
 	    		.forEach(annot -> {
@@ -215,7 +214,7 @@ public class AstBuilder {
     	/*
     	 * Resolve opposites
     	 */
-    	List<Attribute> allAttributes = new ArrayList<Attribute>();
+    	List<Attribute> allAttributes = new ArrayList<>();
     	build
     	.stream()
     	.forEach(sem -> {
@@ -294,15 +293,5 @@ public class AstBuilder {
 		ParseResult<ModelUnit> parseRes = parse(filePath);
 		parseRes.setSourceFile(filePath);
 		return parseRes;
-	}
-	
-    private static String getFileContent(String implementionPath) {
-		String fileContent = "";
-		try {
-			fileContent = new String(Files.readAllBytes(Paths.get(implementionPath)));
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		return fileContent;
 	}
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/Dsl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/Dsl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.parser;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -19,13 +21,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 public class Dsl {
 	
 	String sourceFile;
-	List<String> allSyntaxes = new ArrayList<String>();
-	List<String> allSemantics = new ArrayList<String>();
+	List<String> allSyntaxes = new ArrayList<>();
+	List<String> allSemantics = new ArrayList<>();
 	
 	public Dsl(List<String> syntaxes, List<String> semantics) {
 		this.allSyntaxes.addAll(syntaxes);
@@ -44,6 +45,7 @@ public class Dsl {
 			dslProp.load(input);
 			input.close();
 		} catch (IOException e) {
+			// TODO Throw the exception: it cannot be handled here
 			e.printStackTrace();
 		}
 		
@@ -80,17 +82,16 @@ public class Dsl {
 			Properties dslProp = new Properties();
 			dslProp.put("syntax", String.join(",", allSyntaxes));
 			dslProp.put("behavior", String.join(",", allSemantics));
-			try {
-				FileOutputStream output = new FileOutputStream(sourceFile);
+			try (FileOutputStream output = new FileOutputStream(sourceFile)) {
 				dslProp.store(output,"");
-				output.close();
 			} catch (IOException e) {
+				// TODO Throw the exception: it cannot be handled here
 				e.printStackTrace();
 			}
 		}
 	}
 	
 	protected List<String> trim(String[] uris) {
-		return Arrays.asList(uris).stream().map(s->s.trim()).collect(Collectors.toList());
+		return Arrays.asList(uris).stream().map(s->s.trim()).collect(toList());
 	}
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/DslBuilder.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/DslBuilder.java
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.parser;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.eclipse.acceleo.query.runtime.IQueryEnvironment;
 import org.eclipse.emf.common.util.URI;
@@ -44,7 +45,9 @@ public class DslBuilder {
 	}
 
 	/**
-     * Setup the eval environment & parse semantic files
+     * Setups the eval environment & parse semantic files.
+     * <p>
+     * Dynamically loads the ECore metamodels specified in {@link Dsl#getAllSemantics() dsl' semantics}.
      */
     public List<ParseResult<ModelUnit>> parse(Dsl dsl) { //TODO: add an option to clear services & epackages before
     	
@@ -99,7 +102,7 @@ public class DslBuilder {
 	    	.getAllSyntaxes()
 			.stream()
 			.flatMap(syntaxURI -> load(syntaxURI, rs).stream())
-			.collect(Collectors.toList());
+			.collect(toList());
     }
     
     /**
@@ -112,7 +115,7 @@ public class DslBuilder {
 			.getRegisteredEPackages()
 			.stream()
 			.filter(p -> p.getNsURI().startsWith(ModelBuilder.RUNTIME_ALE_NSURI))
-			.collect(Collectors.toList());
+			.collect(toList());
     	toRemove.forEach(p -> queryEnvironment.removeEPackage(p));
     }
     
@@ -141,6 +144,6 @@ public class DslBuilder {
 	    	.stream()
 	    	.filter(o -> o instanceof EPackage)
 	    	.map(o -> (EPackage) o)
-	    	.collect(Collectors.toList());
+	    	.collect(toList());
     }
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ParseResult.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ParseResult.java
@@ -27,8 +27,8 @@ import org.eclipse.emf.common.util.Diagnostic;
  */
 public class ParseResult<T> {
 	private String sourceFile;
-	private final Map<Object, Integer> startPositions = new HashMap<Object, Integer>();
-	private final Map<Object, Integer> endPositions = new HashMap<Object, Integer>();
+	private final Map<Object, Integer> startPositions = new HashMap<>();
+	private final Map<Object, Integer> endPositions = new HashMap<>();
 	private Diagnostic diagnostic;
 	private T root;
 	

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.validation;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -64,12 +65,12 @@ public class NameValidator implements IValidator {
 	}
 	
 	public List<IValidationMessage> validateModelBehavior(List<ModelUnit> units) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check ModelUnit names are unique
 		 */
-		List<String> declarations = new ArrayList<String>();
+		List<String> declarations = new ArrayList<>();
 		units
 		.stream()
 		.forEach(unit -> {
@@ -93,12 +94,12 @@ public class NameValidator implements IValidator {
 	@Override
 	public List<IValidationMessage> validateModelUnit(ModelUnit unit) {
 		
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check duplication of RuntimeClass
 		 */
-		List<String> declarations = new ArrayList<String>(); 
+		List<String> declarations = new ArrayList<>(); 
 		unit
 		.getClassDefinitions()
 		.stream()
@@ -121,7 +122,7 @@ public class NameValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateExtendedClass(ExtendedClass xtdClass) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		//TODO: check cycles in 'extends'
 		msgs.addAll(validateBehavioredClass(xtdClass));
@@ -173,7 +174,7 @@ public class NameValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateRuntimeClass(RuntimeClass classDef) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		msgs.addAll(validateBehavioredClass(classDef));
 		
@@ -181,12 +182,12 @@ public class NameValidator implements IValidator {
 	}
 	
 	private List<IValidationMessage> validateBehavioredClass(BehavioredClass clazz) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check attributes names
 		 */
-		List<String> declarations = new ArrayList<String>(); 
+		List<String> declarations = new ArrayList<>(); 
 		clazz
 		.getAttributes()
 		.stream()
@@ -224,7 +225,7 @@ public class NameValidator implements IValidator {
 		/*
 		 * Check operation duplication
 		 */
-		List<Method> previousOp = new ArrayList<Method>(); 
+		List<Method> previousOp = new ArrayList<>(); 
 		for (Method mtd : clazz.getMethods()) {
 			boolean isConflict = previousOp.stream().anyMatch(prevOp -> isMatching(mtd, prevOp));
 			if(isConflict) {
@@ -243,12 +244,12 @@ public class NameValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateMethod(Method mtd) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check parameter name
 		 */
-		List<String> declarations = new ArrayList<String>();
+		List<String> declarations = new ArrayList<>();
 		if(mtd.getOperationRef() != null) {
 			for (EParameter param : mtd.getOperationRef().getEParameters()) {
 				String name = param.getName();
@@ -295,7 +296,7 @@ public class NameValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateFeatureAssignment(FeatureAssignment featAssign) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check the assigned feature exist 
@@ -339,7 +340,7 @@ public class NameValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateFeatureInsert(FeatureInsert featInsert) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check the assigned feature exist 
@@ -383,7 +384,7 @@ public class NameValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateFeatureRemove(FeatureRemove featRemove) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check the assigned feature exist 
@@ -427,7 +428,7 @@ public class NameValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateVariableAssignment(VariableAssignment varAssign) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check name
@@ -473,7 +474,7 @@ public class NameValidator implements IValidator {
 	}
 	
 	public List<IValidationMessage> validateVariableDeclaration(VariableDeclaration varDecl) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check name
@@ -510,7 +511,7 @@ public class NameValidator implements IValidator {
 	}
 	
 	public List<IValidationMessage> validateForEach(ForEach loop) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		if(loop.getVariable().equals("result")){
 			msgs.add(new ValidationMessage(
@@ -544,22 +545,22 @@ public class NameValidator implements IValidator {
 	}
 	
 	public List<IValidationMessage> validateIf(If ifStmt) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 	
 	public List<IValidationMessage> validateWhile(While loop) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 	
 	private String getSignature(Method op) {
-		EOperation eOp = ((Method)op).getOperationRef();
+		EOperation eOp = op.getOperationRef();
 		if(eOp != null) {
 			String paramsToString = 
 					eOp
 					.getEParameters()
 					.stream()
 					.map(param -> param.getEType().getName())
-					.collect(Collectors.joining(",","(",")"));
+					.collect(joining(",","(",")"));
 			
 			return eOp.getName() + paramsToString; 
 		}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/OpenClassValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/OpenClassValidator.java
@@ -42,7 +42,7 @@ public class OpenClassValidator implements IValidator {
 	public static final String EXTENDS_ORDER = "The extended EClass %s have to be after %s";
 	
 	BaseValidator base;
-	List<ExtendedClass> duplicatedExensions = new ArrayList<ExtendedClass>();
+	List<ExtendedClass> duplicatedExensions = new ArrayList<>();
 
 	@Override
 	public void setBase(BaseValidator baseValidator) {
@@ -51,7 +51,7 @@ public class OpenClassValidator implements IValidator {
 
 	@Override
 	public List<IValidationMessage> validateModelBehavior(List<ModelUnit> units) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		duplicatedExensions.clear();
 		
 		Multimap<EClass, ExtendedClass> extensionByBase = ArrayListMultimap.create();
@@ -69,7 +69,7 @@ public class OpenClassValidator implements IValidator {
 				extensions
 				.stream()
 				.skip(1)
-				.filter(xtd -> xtd.getExtends().size() == 0)
+				.filter(xtd -> xtd.getExtends().isEmpty())
 				.forEach(xtd -> duplicatedExensions.add(xtd));
 			}
 		});
@@ -79,14 +79,14 @@ public class OpenClassValidator implements IValidator {
 
 	@Override
 	public List<IValidationMessage> validateModelUnit(ModelUnit unit) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		return msgs;
 	}
 
 	@Override
 	public List<IValidationMessage> validateExtendedClass(ExtendedClass xtdClass) {
 		
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		if(duplicatedExensions.contains(xtdClass)) {
 			msgs.add(new ValidationMessage(
@@ -130,52 +130,52 @@ public class OpenClassValidator implements IValidator {
 
 	@Override
 	public List<IValidationMessage> validateRuntimeClass(RuntimeClass classDef) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateMethod(Method mtd) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateFeatureAssignment(FeatureAssignment featAssign) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateFeatureInsert(FeatureInsert featInsert) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateFeatureRemove(FeatureRemove featRemove) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateVariableAssignment(VariableAssignment varAssign) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateVariableDeclaration(VariableDeclaration varDecl) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateForEach(ForEach loop) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateIf(If ifStmt) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 	@Override
 	public List<IValidationMessage> validateWhile(While loop) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.validation;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -74,17 +76,17 @@ public class TypeValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateModelBehavior(List<ModelUnit> units) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 	
 	@Override
 	public List<IValidationMessage> validateModelUnit(ModelUnit unit) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 	
 	@Override
 	public List<IValidationMessage> validateExtendedClass(ExtendedClass xtdClass) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		msgs.addAll(validateBehavioredClass(xtdClass));
 		
@@ -123,7 +125,7 @@ public class TypeValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateRuntimeClass(RuntimeClass classDef) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		msgs.addAll(validateBehavioredClass(classDef));
 		
@@ -131,7 +133,7 @@ public class TypeValidator implements IValidator {
 	}
 	
 	private List<IValidationMessage> validateBehavioredClass(BehavioredClass clazz) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		clazz
 		.getAttributes()
@@ -146,7 +148,7 @@ public class TypeValidator implements IValidator {
 					inferredTypes
 					.stream()
 					.map(type -> getQualifiedName(type))
-					.collect(Collectors.joining(",","[","]"));
+					.collect(joining(",","[","]"));
 				msgs.add(new ValidationMessage(
 						ValidationMessageLevel.ERROR,
 						String.format(INCOMPATIBLE_TYPE, getQualifiedName(att.getFeatureRef().getEType()),types),
@@ -161,7 +163,7 @@ public class TypeValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateMethod(Method mtd) {
-		return new ArrayList<IValidationMessage>();
+		return new ArrayList<>();
 	}
 	
 	@Override
@@ -181,13 +183,13 @@ public class TypeValidator implements IValidator {
 	}
 	
 	private List<IValidationMessage> validateAssignment(Statement stmt, Expression targetExp, String featureName, Expression valueExp, boolean isInsert) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Collect feature types
 		 */
 		Set<IType> targetTypes = base.getPossibleTypes(targetExp);
-		Set<EClassifierType> featureTypes = new HashSet<EClassifierType>();
+		Set<EClassifierType> featureTypes = new HashSet<>();
 		boolean isCollection = false;
 		for(IType type: targetTypes){
 			if(type.getType() instanceof EClass){
@@ -225,7 +227,7 @@ public class TypeValidator implements IValidator {
 					featureTypes
 					.stream()
 					.map(type -> getQualifiedName(type))
-					.collect(Collectors.joining(",","[","]"));
+					.collect(joining(",","[","]"));
 			msgs.add(new ValidationMessage(
 					ValidationMessageLevel.ERROR,
 					String.format(COLLECTION_TYPE,inferredToString),
@@ -245,6 +247,8 @@ public class TypeValidator implements IValidator {
 				for(IType inferredType: inferredTypes){
 					if(inferredType instanceof AbstractCollectionType) {
 						IType collectionType = ((AbstractCollectionType)inferredType).getCollectionType();
+						
+						// FIXME Is something missing here?
 					}
 				}
 				boolean isAnyAssignable = false;
@@ -266,12 +270,12 @@ public class TypeValidator implements IValidator {
 							inferredTypes
 							.stream()
 							.map(type -> getQualifiedName(type))
-							.collect(Collectors.joining(",","[","]"));
+							.collect(joining(",","[","]"));
 					String featureToString = 
 							featureTypes
 							.stream()
 							.map(type -> getQualifiedName(type.getType()))
-							.collect(Collectors.joining(",","(",")"));
+							.collect(joining(",","(",")"));
 					msgs.add(new ValidationMessage(
 							ValidationMessageLevel.ERROR,
 							String.format(INCOMPATIBLE_TYPE,"[Collection"+featureToString+"]",inferredToString),
@@ -299,12 +303,12 @@ public class TypeValidator implements IValidator {
 							inferredTypes
 							.stream()
 							.map(type -> getQualifiedName(type))
-							.collect(Collectors.joining(",","[","]"));
+							.collect(joining(",","[","]"));
 					String featureToString = 
 							featureTypes
 							.stream()
 							.map(type -> getQualifiedName(type.getType()))
-							.collect(Collectors.joining(",","[","]"));
+							.collect(joining(",","[","]"));
 					
 					msgs.add(new ValidationMessage(
 							ValidationMessageLevel.ERROR,
@@ -323,7 +327,7 @@ public class TypeValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateVariableAssignment(VariableAssignment varAssign) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		Set<IType> declaringTypes = findDeclaredTypes(varAssign);
 		if(varAssign.getName().equals("result")) {
@@ -356,7 +360,7 @@ public class TypeValidator implements IValidator {
 								inferredTypes
 								.stream()
 								.map(type -> getQualifiedName(type))
-								.collect(Collectors.joining(",","[","]"));
+								.collect(joining(",","[","]"));
 						msgs.add(new ValidationMessage(
 								ValidationMessageLevel.ERROR,
 								String.format(INCOMPATIBLE_TYPE,"["+getTypeQualifiedNameForOperationResult(declaredType, eOperation)+"]",types),
@@ -390,12 +394,12 @@ public class TypeValidator implements IValidator {
 							declaringTypes
 							.stream()
 							.map(type -> getTypeQualifiedNameForVar(type,declaration))
-							.collect(Collectors.joining(",","[","]"));
+							.collect(joining(",","[","]"));
 					String inferredToString = 
 							inferredTypes
 							.stream()
 							.map(type -> getQualifiedName(type))
-							.collect(Collectors.joining(",","[","]"));
+							.collect(joining(",","[","]"));
 					
 					msgs.add(new ValidationMessage(
 							ValidationMessageLevel.ERROR,
@@ -483,7 +487,7 @@ public class TypeValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateVariableDeclaration(VariableDeclaration varDecl) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		if(varDecl.getInitialValue() != null) {
 			
@@ -505,7 +509,7 @@ public class TypeValidator implements IValidator {
 								inferredTypes
 								.stream()
 								.map(type -> getQualifiedName(type))
-								.collect(Collectors.joining(",","[","]"));
+								.collect(joining(",","[","]"));
 
 						msgs.add(new ValidationMessage(
 								ValidationMessageLevel.ERROR,
@@ -528,7 +532,7 @@ public class TypeValidator implements IValidator {
 								inferredTypes
 								.stream()
 								.map(type -> getQualifiedName(type))
-								.collect(Collectors.joining(",","[","]"));
+								.collect(joining(",","[","]"));
 						
 						msgs.add(new ValidationMessage(
 								ValidationMessageLevel.ERROR,
@@ -546,7 +550,7 @@ public class TypeValidator implements IValidator {
 	
 	@Override
 	public List<IValidationMessage> validateForEach(ForEach loop) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 		
 		/*
 		 * Check expression is collection
@@ -563,7 +567,7 @@ public class TypeValidator implements IValidator {
 					.getPossibleTypes(loop.getCollectionExpression())
 					.stream()
 					.map(type -> getQualifiedName(type))
-					.collect(Collectors.joining(",","[","]"));
+					.collect(joining(",","[","]"));
 			msgs.add(new ValidationMessage(
 					ValidationMessageLevel.ERROR,
 					String.format(COLLECTION_TYPE,inferredToString),
@@ -590,7 +594,7 @@ public class TypeValidator implements IValidator {
 	}
 	
 	private List<IValidationMessage> validateIsBoolean(Expression exp) {
-		List<IValidationMessage> msgs = new ArrayList<IValidationMessage>();
+		List<IValidationMessage> msgs = new ArrayList<>();
 
 		Set<IType> selectorTypes = base.getPossibleTypes(exp);
 		boolean onlyNotBoolean = true;
@@ -606,7 +610,7 @@ public class TypeValidator implements IValidator {
 					selectorTypes
 					.stream()
 					.map(type -> getQualifiedName(type))
-					.collect(Collectors.joining(",","[","]"));
+					.collect(joining(",","[","]"));
 			msgs.add(new ValidationMessage(
 					ValidationMessageLevel.ERROR,
 					String.format(BOOLEAN_TYPE,inferredToString),
@@ -780,7 +784,7 @@ public class TypeValidator implements IValidator {
 		return pkgs
 			.stream()
 			.map(p -> p.getName())
-			.collect(Collectors.joining("::"));
+			.collect(joining("::"));
 	}
 	
 	private static String getQualifiedName(IType type) {

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/AlePreferenceStore.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/AlePreferenceStore.java
@@ -15,10 +15,10 @@ import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
 public class AlePreferenceStore extends ScopedPreferenceStore{
 
-	public static String ALE_PREF_XTEXT_FOCUS = "xtextFocus";
-	public static String ALE_PREF_SERIALIZATION = "serialization";
-	public static String ALE_PREF_SERIALIZATION_ALE = "ALE";
-	public static String ALE_PREF_SERIALIZATION_Ecore = "Ecore";
+	public static final String ALE_PREF_XTEXT_FOCUS = "xtextFocus";
+	public static final String ALE_PREF_SERIALIZATION = "serialization";
+	public static final String ALE_PREF_SERIALIZATION_ALE = "ALE";
+	public static final String ALE_PREF_SERIALIZATION_Ecore = "Ecore";
 	
 	public AlePreferenceStore(IScopeContext context, String qualifier) {
 		super(context, qualifier);

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/AlePropertyPage.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/AlePropertyPage.java
@@ -19,7 +19,6 @@ import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.RadioGroupFieldEditor;
 import org.eclipse.ui.IWorkbenchPropertyPage;
-import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
 public class AlePropertyPage extends FieldEditorPreferencePage implements IWorkbenchPropertyPage {
 	
@@ -44,8 +43,7 @@ public class AlePropertyPage extends FieldEditorPreferencePage implements IWorkb
 	
 	@Override
 	protected IPreferenceStore doGetPreferenceStore() {
-		ScopedPreferenceStore store = new AlePreferenceStore(new ProjectScope(project), Activator.PLUGIN_ID); 
-		return store;
+		return new AlePreferenceStore(new ProjectScope(project), Activator.PLUGIN_ID); 
     }
 
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/AleLaunchConfigurationTab.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/AleLaunchConfigurationTab.java
@@ -18,8 +18,6 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
@@ -129,12 +127,9 @@ public class AleLaunchConfigurationTab extends AbstractLaunchConfigurationTab {
 	private void createModelWidgets(Composite parent) {
 		modelSelection = new Text(parent, SWT.SINGLE | SWT.BORDER);
 		modelSelection.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-		modelSelection.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				updateLaunchConfigurationDialog();
-			}
-		});
+		modelSelection.addModifyListener(modifyEvent ->
+				updateLaunchConfigurationDialog()
+		);
 		
 		Button modelLocationButton = createPushButton(parent, "Browse", null);
 		modelLocationButton.addSelectionListener(new SelectionAdapter() {
@@ -154,12 +149,9 @@ public class AleLaunchConfigurationTab extends AbstractLaunchConfigurationTab {
 	private void createDslWidgets(Composite parent) {
 		dslSelection = new Text(parent, SWT.SINGLE | SWT.BORDER);
 		dslSelection.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-		dslSelection.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent e) {
-				updateLaunchConfigurationDialog();
-			}
-		});
+		dslSelection.addModifyListener(modifyEvent ->
+				updateLaunchConfigurationDialog()
+		);
 		
 		Button dslLocationButton = createPushButton(parent, "Browse", null);
 		dslLocationButton.addSelectionListener(new SelectionAdapter() {

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/LaunchShortcut.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/LaunchShortcut.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.ide.ui.launchconfig;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.debug.ui.ILaunchShortcut;
 import org.eclipse.jface.viewers.ISelection;
@@ -18,7 +17,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.ide.ResourceUtil;
 
 public class LaunchShortcut implements ILaunchShortcut {
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/services/Services.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/services/Services.java
@@ -10,10 +10,12 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.ide.ui.services;
 
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -85,9 +87,7 @@ public class Services {
     			return xtdClass
     				.getMethods()
     				.stream()
-    				.filter(mtd -> mtd.getOperationRef() != null && mtd.getOperationRef().getName().equals(op.getName()) && mtd.getOperationRef().getEContainingClass() == xtdClass.getBaseClass())
-    				.findAny()
-    				.isPresent();
+    				.anyMatch(mtd -> mtd.getOperationRef() != null && mtd.getOperationRef().getName().equals(op.getName()) && mtd.getOperationRef().getEContainingClass() == xtdClass.getBaseClass());
     		}
     	}
     	
@@ -114,10 +114,10 @@ public class Services {
 				.stream()
 				.filter(elem -> elem instanceof ModelUnit)
 				.map(elm -> (ModelUnit) elm)
-				.collect(Collectors.toList());
+				.collect(toList());
     	}
     	
-    	return new ArrayList<ModelUnit>();
+    	return new ArrayList<>();
     }
     
     public List<Attribute> getDynaAttrib(EClass cls){
@@ -134,10 +134,10 @@ public class Services {
 				.getAttributes()
 				.stream()
 				.filter(att -> att.getFeatureRef() instanceof EAttribute) //FIXME: show also not displayed EReferences
-				.collect(Collectors.toList());
+				.collect(toList());
 		}
     	
-    	return new ArrayList<Attribute>();
+    	return new ArrayList<>();
     }
     
     public List<Attribute> getDynaAttrib(RuntimeClass cls){
@@ -146,7 +146,7 @@ public class Services {
 			.getAttributes()
 			.stream()
 			.filter(att -> att.getFeatureRef() instanceof EAttribute) //FIXME: show also not displayed EReferences
-			.collect(Collectors.toList());
+			.collect(toList());
     }
     
     public List<Method> getMethod(EClass cls) {
@@ -165,10 +165,10 @@ public class Services {
 				.filter(op -> op instanceof Method)
 				.map(op -> (Method) op)
 				.filter(op -> !isImplemented(op.getOperationRef())) //TODO: improve
-				.collect(Collectors.toList());
+				.collect(toList());
 		}
     	
-    	return new ArrayList<Method>();
+    	return new ArrayList<>();
     }
     
     public List<Method> getMethod(RuntimeClass cls) {
@@ -178,7 +178,7 @@ public class Services {
 			.stream()
 			.filter(op -> op instanceof Method)
 			.map(op -> (Method) op)
-			.collect(Collectors.toList());
+			.collect(toList());
     }
     
     public ModelUnit getModelUnit(EPackage pkg) {
@@ -210,7 +210,7 @@ public class Services {
 				document.modify(new IUnitOfWork.Void<XtextResource>() {
 					@Override
 					public void process(XtextResource state) throws Exception {
-						if(state.getContents().size() > 0) {
+						if(!state.getContents().isEmpty()) {
 							Unit root = (Unit) state.getContents().get(0);
 							
 							String returnType = "void";
@@ -220,7 +220,7 @@ public class Services {
 							String parameters = op.getEParameters()
 								.stream()
 								.map(p -> p.getEType().getName()+" "+ p.getName())
-								.collect(Collectors.joining(",","(",")"));
+								.collect(joining(",","(",")"));
 							String opName = op.getName();
 							String content = "/* Write your code here */";
 							String template = "\toverride "+returnType+" "+opName+" "+parameters+" {\n\t\t"+content+"\n\t}\n";
@@ -297,7 +297,7 @@ public class Services {
 				document.modify(new IUnitOfWork.Void<XtextResource>() {
 					@Override
 					public void process(XtextResource state) throws Exception {
-						if(state.getContents().size() > 0) {
+						if(!state.getContents().isEmpty()) {
 							Unit root = (Unit) state.getContents().get(0);
 							
 							String returnType = "int";
@@ -394,7 +394,7 @@ public class Services {
 				document.modify(new IUnitOfWork.Void<XtextResource>() {
 					@Override
 					public void process(XtextResource state) throws Exception {
-						if(state.getContents().size() > 0) {
+						if(!state.getContents().isEmpty()) {
 							Unit root = (Unit) state.getContents().get(0);
 							
 							String template = "\n\t"+typeName+" "+featureName+";\n";
@@ -411,7 +411,7 @@ public class Services {
 								if(!attrSearch.isPresent()){
 									int endOffset = node.getEndOffset();
 									Iterable<ILeafNode> leafs = node.getLeafNodes();
-									ArrayList<ILeafNode> l = new ArrayList<ILeafNode>();
+									ArrayList<ILeafNode> l = new ArrayList<>();
 									leafs.forEach(e -> l.add(e));
 									
 									Optional<ILeafNode> openBraceSearch = l.stream()
@@ -434,7 +434,7 @@ public class Services {
 										if(!attrSearch.isPresent()){
 											int endOffset = node.getEndOffset();
 											Iterable<ILeafNode> leafs = node.getLeafNodes();
-											ArrayList<ILeafNode> l = new ArrayList<ILeafNode>();
+											ArrayList<ILeafNode> l = new ArrayList<>();
 											leafs.forEach(e -> l.add(e));
 											
 											Optional<ILeafNode> openBraceSearch = l.stream()
@@ -495,7 +495,7 @@ public class Services {
 				document.modify(new IUnitOfWork.Void<XtextResource>() {
 					@Override
 					public void process(XtextResource state) throws Exception {
-						if(state.getContents().size() > 0) {
+						if(!state.getContents().isEmpty()) {
 							Unit root = (Unit) state.getContents().get(0);
 							
 							String newClassName = "NewRuntimeClass";
@@ -569,7 +569,7 @@ public class Services {
 				.stream()
 				.filter(elem -> elem instanceof ModelUnit)
 				.map(elm -> (ModelUnit) elm)
-				.collect(Collectors.toList());
+				.collect(toList());
 			
 			
 	    	Optional<RuntimeClass> searchCls = 

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/WorkbenchDsl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/WorkbenchDsl.java
@@ -10,11 +10,12 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.ide;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.resources.IResource;
@@ -44,10 +45,10 @@ public class WorkbenchDsl extends Dsl {
 }
 	
 	private void resolveUris() {
-		ArrayList<String> newSemantics = new ArrayList<String>();
-		getAllSemantics()
+		List<String> newSemantics = getAllSemantics()
 			.stream()
-			.forEach(elem -> newSemantics.add(URI.createFileURI(convertToFile(elem)).toFileString()));//expect system file path
+			.map(elem -> URI.createFileURI(convertToFile(elem)).toFileString())
+			.collect(toList());
 		getAllSemantics().clear();
 		getAllSemantics().addAll(newSemantics);
 	}
@@ -109,6 +110,6 @@ public class WorkbenchDsl extends Dsl {
 	 * Convert platform:/resource/ to platform:/plugin/
 	 */
 	private static URI resourceToPlugin(URI uri) {
-		return uri.createPlatformPluginURI(uri.toPlatformString(true), true);
+		return URI.createPlatformPluginURI(uri.toPlatformString(true), true);
 	}
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/listener/AleWorkspaceListener.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/listener/AleWorkspaceListener.java
@@ -38,7 +38,7 @@ public class AleWorkspaceListener implements IResourceChangeListener {
 
 	public AleWorkspaceListener(Session session, Resource dslRes) {
 		this.session = session;
-		this.files = new LinkedHashSet<IFile>();
+		this.files = new LinkedHashSet<>();
 		this.dslRes = dslRes;
 	}
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/resource/AleResource.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/resource/AleResource.java
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.ide.resource;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
@@ -45,7 +46,7 @@ public class AleResource extends ResourceImpl {
 		if(newParseResult != null) { //TODO: check no parse error
 			unload();
 			parseResult = newParseResult;
-			List<ModelUnit> newContent = parseResult.stream().map(pr -> pr.getRoot()).collect(Collectors.toList());
+			List<ModelUnit> newContent = parseResult.stream().map(pr -> pr.getRoot()).collect(toList());
 			
 			isNotifyEnabled = false;
 			getContents().addAll(newContent);

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
@@ -3,6 +3,8 @@
  */
 package org.eclipse.emf.ecoretools.validation
 
+import com.google.common.collect.Sets
+import java.util.ArrayList
 import java.util.List
 import org.eclipse.acceleo.query.runtime.IValidationMessage
 import org.eclipse.core.resources.IFile
@@ -11,28 +13,24 @@ import org.eclipse.core.resources.IResource
 import org.eclipse.core.resources.IWorkspaceRoot
 import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.IPath
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecoretools.ale.ALEInterpreter
+import org.eclipse.emf.ecoretools.ale.OrderedSet
+import org.eclipse.emf.ecoretools.ale.SeqType
+import org.eclipse.emf.ecoretools.ale.Sequence
+import org.eclipse.emf.ecoretools.ale.SetType
+import org.eclipse.emf.ecoretools.ale.Unit
+import org.eclipse.emf.ecoretools.ale.core.parser.Dsl
 import org.eclipse.emf.ecoretools.ale.core.parser.DslBuilder
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult
 import org.eclipse.emf.ecoretools.ale.core.validation.ALEValidator
-import org.eclipse.emf.ecoretools.ale.core.parser.Dsl
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit
 import org.eclipse.emf.workspace.util.WorkspaceSynchronizer
-import org.eclipse.xtext.validation.Check
-import java.util.ArrayList
-import org.eclipse.emf.common.util.URI
-import org.eclipse.emf.ecoretools.ale.Unit
-import com.google.common.collect.Sets
-import java.util.Set
-import org.eclipse.emf.ecoretools.ale.Sequence
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.Keyword
 import org.eclipse.xtext.nodemodel.impl.HiddenLeafNode
-import org.eclipse.emf.ecoretools.ale.AlePackage
-import org.eclipse.emf.ecoretools.ale.OrderedSet
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.emf.ecoretools.ale.SeqType
-import org.eclipse.emf.ecoretools.ale.SetType
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.validation.Check
 
 /**
  * Delegate validation to ALE validator
@@ -59,7 +57,7 @@ class AleValidator extends AbstractAleValidator {
 		/*
     	 * Register services
     	 */
-    	val List<java.lang.String> services = 
+    	val List<String> services = 
     		parsedSemantics
 	    	.map[getRoot()]
 	    	.filterNull
@@ -119,7 +117,7 @@ class AleValidator extends AbstractAleValidator {
 		dsl.getAllSemantics()
 			.forEach[elem |
 				val uri = URI.createURI(elem);
-				if(ws != null && uri.isPlatform()) {
+				if(ws !== null && uri.isPlatform()) {
 					val file = ws.getRoot().findMember(uri.toPlatformString(true));
 					val path = file.getLocationURI().getRawPath();
 					newSemantics.add(path);

--- a/plugins/org.eclipse.emf.ecoretools.ale/src/org/eclipse/emf/ecoretools/ale/debug/DebugLookupEngine.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale/src/org/eclipse/emf/ecoretools/ale/debug/DebugLookupEngine.java
@@ -26,7 +26,7 @@ public class DebugLookupEngine implements ILookupEngine{
 	
 	public DebugLookupEngine(ILookupEngine wrapped) {
 		this.wrapped = wrapped;
-		this.listeners = new ArrayList<ILookupEngineListener>();
+		this.listeners = new ArrayList<>();
 	}
 	
 	public void registerListener(ILookupEngineListener listener) {

--- a/plugins/org.eclipse.emf.ecoretools.ale/src/org/eclipse/emf/ecoretools/ale/debug/ILookupEngineListener.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale/src/org/eclipse/emf/ecoretools/ale/debug/ILookupEngineListener.java
@@ -10,18 +10,19 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.debug;
 
+import org.eclipse.acceleo.query.runtime.ILookupEngine;
 import org.eclipse.acceleo.query.runtime.IService;
 import org.eclipse.acceleo.query.validation.type.IType;
 
 public interface ILookupEngineListener {
 
 	/**
-	 * Called at the start of ILookupEngine.lookup(String,IType[])
+	 * Called at the start of {@link ILookupEngine#lookup(String, IType[])
 	 */
 	public void preLookup(String name, IType[] argumentTypes);
 	
 	/**
-	 * Called at the end of ILookupEngine.lookup(String,IType[])
+	 * Called at the end of {@link ILookupEngine#lookup(String, IType[])
 	 */
 	public void postLookup(IService foundService);
 	


### PR DESCRIPTION
Main improvements are:
- remove redundant type specifications by the diamond operator <>
- use static imports when calling Collectors' functions

Also brings some little changes:
- [RunModelAction](https://github.com/gemoc/ale-lang/blob/dc514c8fd46d27b89124dbf43bbcb2424fbbb310/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/RunModelAction.java#L84): wrap execution of the interpreter in a try-catch statement to ensure `System.out` is always reset to its original value
- [RunModelAction](https://github.com/gemoc/ale-lang/blob/dc514c8fd46d27b89124dbf43bbcb2424fbbb310/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/RunModelAction.java#L115): (possibly breaking change) cancel the execution of the interpreter when the main thread is interrupted instead of just printing the stack trace
- [ALEInterpreter](https://github.com/gemoc/ale-lang/blob/dc514c8fd46d27b89124dbf43bbcb2424fbbb310/plugins/org.eclipse.emf.ecoretools.ale/src/org/eclipse/emf/ecoretools/ale/ALEInterpreter.java#L213): extract the search for the `@main` operator into a dedicated method to simplify the code