### PR TITLE
Jenkinsfile4ale

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,59 @@
+// Pipeline using declarative syntax
+// you can fall down to script syntax using the script { } command 
+pipeline {
+
+	options {
+		buildDiscarder( logRotator(numToKeepStr:'60', artifactNumToKeepStr: '1'))
+	}
+	tools {
+        	maven 'apache-maven-latest'
+        	jdk 'oracle-jdk8-latest'
+	}
+	// 
+	stages {
+		
+		stage('Build and verify') {
+	    	steps { 
+				wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+					sh "mvn -Dmaven.test.failure.ignore clean verify --errors --show-version"
+				}
+			}
+			post {
+				success {
+					junit 'tests/**/target/surefire-reports/TEST-*.xml' 
+				}
+				always {
+					sh "./gemoc-studio/dev_support/jenkins/showGitBranches.sh ."
+				}
+			}
+	 	}
+		stage("Archive in Jenkins") {
+			steps {
+				echo "archive artifact"
+				archiveArtifacts 'releng/org.eclipse.emf.ecoretools.ale.updatesite/target/repository/**, **/screenshots/**'
+			}
+		}
+	}
+	post { 
+		// send a mail on unsuccessful and fixed builds
+        unsuccessful { // means unstable || failure || aborted
+            emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
+			            body: '''Check console output at $BUILD_URL to view the results.''',
+			            recipientProviders: [culprits(), requestor()], 
+			            to: 'didier.vojtisek@inria.fr'
+        }
+        fixed { // back to normal
+            emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
+			            body: '''Check console output at $BUILD_URL to view the results.''',
+			            recipientProviders: [culprits(), requestor()], 
+			            to: 'didier.vojtisek@inria.fr'
+        }
+		// changed { }
+		unstable {
+			echo 'Unstable' 
+		}
+		failure {
+			echo 'Failure' 
+		}
+	}
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Pipeline using declarative syntax
 // you can fall down to script syntax using the script { } command 
 pipeline {
-
+	agent any
 	options {
 		buildDiscarder( logRotator(numToKeepStr:'60', artifactNumToKeepStr: '1'))
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,9 +22,6 @@ pipeline {
 				success {
 					junit 'tests/**/target/surefire-reports/TEST-*.xml' 
 				}
-				always {
-					sh "./gemoc-studio/dev_support/jenkins/showGitBranches.sh ."
-				}
 			}
 	 	}
 		stage("Archive in Jenkins") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,11 +33,8 @@ pipeline {
 		stage("Deploy") {
 			when { tag "release-*"}
 			steps{
-				ant {
-					target('upload')
-					prop('key.file','/builds/.ssh/id_rsa')
-					buildFile('releng/promotion_build.xml')
-					antInstallation('Ant_1.8.4')
+				withAnt(installation: 'Ant_1.8.4') {
+				    sh "ant -Dkey.file=/builds/.ssh/id_rsa -f releng/promotion_build.xml upload"
 				}
 			}
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         fixed { // back to normal
             emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
 			            body: '''Check console output at $BUILD_URL to view the results.''',
-			            recipientProviders: [culprits(), requestor()], 
+			            recipientProviders: [[$class: 'CulpritsRecipientProvider'],[$class: 'RequesterRecipientProvider']], 
 			            to: 'didier.vojtisek@inria.fr'
         }
 		// changed { }
@@ -46,14 +46,14 @@ pipeline {
 			echo 'Unstable' 
             emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
 			            body: '''Check console output at $BUILD_URL to view the results.''',
-			            recipientProviders: [culprits(), requestor()], 
+			            recipientProviders: [[$class: 'CulpritsRecipientProvider'],[$class: 'RequesterRecipientProvider']], 
 			            to: 'didier.vojtisek@inria.fr'
 		}
 		failure {
 			echo 'Failure' 
             emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
 			            body: '''Check console output at $BUILD_URL to view the results.''',
-			            recipientProviders: [culprits(), requestor()], 
+			            recipientProviders: [[$class: 'CulpritsRecipientProvider'],[$class: 'RequesterRecipientProvider']], 
 			            to: 'didier.vojtisek@inria.fr'
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,13 +35,6 @@ pipeline {
 		}
 	}
 	post { 
-		// send a mail on unsuccessful and fixed builds
-        unsuccessful { // means unstable || failure || aborted
-            emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
-			            body: '''Check console output at $BUILD_URL to view the results.''',
-			            recipientProviders: [culprits(), requestor()], 
-			            to: 'didier.vojtisek@inria.fr'
-        }
         fixed { // back to normal
             emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
 			            body: '''Check console output at $BUILD_URL to view the results.''',
@@ -51,9 +44,17 @@ pipeline {
 		// changed { }
 		unstable {
 			echo 'Unstable' 
+            emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
+			            body: '''Check console output at $BUILD_URL to view the results.''',
+			            recipientProviders: [culprits(), requestor()], 
+			            to: 'didier.vojtisek@inria.fr'
 		}
 		failure {
 			echo 'Failure' 
+            emailext 	subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
+			            body: '''Check console output at $BUILD_URL to view the results.''',
+			            recipientProviders: [culprits(), requestor()], 
+			            to: 'didier.vojtisek@inria.fr'
 		}
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,17 @@ pipeline {
 				archiveArtifacts 'releng/org.eclipse.emf.ecoretools.ale.updatesite/target/repository/**, **/screenshots/**'
 			}
 		}
+		stage("Deploy") {
+			when { tag "release-*"}
+			steps{
+				ant {
+					target('upload')
+					prop('key.file','/builds/.ssh/id_rsa')
+					buildFile('releng/promotion_build.xml')
+					antInstallation('Ant_1.8.4')
+				}
+			}
+		}
 	}
 	post { 
         fixed { // back to normal


### PR DESCRIPTION
This PR adds a jenkinsfile allowing to build ALE in multibranch configuration.

I've also set up a new CI configuration https://ci.inria.fr/gemoc/job/ale-lang/ that looks for changes in the branches.

This contributes to https://github.com/gemoc/ale-lang/issues/63 by building all branches in the repo


The deployment of the artifact to the web site is triggered by adding a tag "release-XXX" to the commit (should be done only on master branch)

note: it is important to clean old unused branches in order to save disk space on the CI server.