### PR TITLE
Improve the += and -= operators

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DynamicFeatureRegistry.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DynamicFeatureRegistry.java
@@ -147,6 +147,10 @@ public class DynamicFeatureRegistry {
 					String concat = featureValue + "" + newValue;
 					extendedInstance.eSet(feature, concat);
 				}
+				else if(featureValue instanceof Integer && newValue instanceof Integer) {
+					Integer sum = (Integer) featureValue + (Integer) newValue;
+					extendedInstance.eSet(feature, sum);
+				}
 			}
 			else {
 				//TODO: error feature not found
@@ -167,6 +171,10 @@ public class DynamicFeatureRegistry {
 				Object featureValue = extendedInstance.eGet(feature);
 				if(featureValue instanceof List){
 					((List)featureValue).remove(newValue);
+				}
+				else if(featureValue instanceof Integer && newValue instanceof Integer) {
+					Integer substraction = (Integer) featureValue - (Integer) newValue;
+					extendedInstance.eSet(feature, substraction);
 				}
 				else {
 					//TODO: Error

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DynamicFeatureRegistry.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DynamicFeatureRegistry.java
@@ -143,8 +143,9 @@ public class DynamicFeatureRegistry {
 				if(featureValue instanceof List){
 					((List)featureValue).add(newValue);
 				}
-				else {
-					//error
+				else if(featureValue instanceof String){
+					String concat = featureValue + "" + newValue;
+					extendedInstance.eSet(feature, concat);
 				}
 			}
 			else {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -211,6 +211,10 @@ public class MethodEvaluator {
 			else if(variableValue instanceof String) {
 				scope.put(varInsert.getName(), variableValue + "" + insertedValue);
 			}
+			else if(variableValue instanceof Integer && insertedValue instanceof Integer) {
+				Integer sum = (Integer) variableValue + (Integer) insertedValue;
+				scope.put(varInsert.getName(), sum);
+			}
 			else {
 				BasicDiagnostic child = new BasicDiagnostic(
 						Diagnostic.ERROR,
@@ -239,6 +243,10 @@ public class MethodEvaluator {
 				else {
 					((List)variableValue).remove(insertedValue);
 				}
+			}
+			else if(variableValue instanceof Integer && insertedValue instanceof Integer) {
+				Integer substraction = (Integer) variableValue - (Integer) insertedValue;
+				scope.put(varInsert.getName(), substraction);
 			}
 			else {
 				BasicDiagnostic child = new BasicDiagnostic(

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -209,7 +209,15 @@ public class MethodEvaluator {
 				}
 			}
 			else {
-				//TOOD: error: try to insert in  non-list variable
+				BasicDiagnostic child = new BasicDiagnostic(
+						Diagnostic.ERROR,
+						MethodEvaluator.PLUGIN_ID,
+						0,
+						String.format("Variable '%s' is not a list, cannot insert %s", varInsert.getName(), insertedValue),
+						new Object[] {varInsert.getValue()}
+				);
+				diagnostic.add(child);
+				throw new CriticalFailure("Unable to insert a value in " + varInsert.getName(), diagnostic);
 			}
 		}
 		
@@ -231,7 +239,15 @@ public class MethodEvaluator {
 				}
 			}
 			else {
-				//TOOD: error: try to insert in  non-list variable
+				BasicDiagnostic child = new BasicDiagnostic(
+						Diagnostic.ERROR,
+						MethodEvaluator.PLUGIN_ID,
+						0,
+						String.format("Variable '%s' is not a list, cannot remove %s", varInsert.getName(), insertedValue),
+						new Object[] {varInsert.getValue()}
+				);
+				diagnostic.add(child);
+				throw new CriticalFailure("Unable to remove a value from " + varInsert.getName(), diagnostic);
 			}
 		}
 		
@@ -252,7 +268,20 @@ public class MethodEvaluator {
 				}
 			}
 			else {
-				dynamicFeatureAccess.insertDynamicFeatureValue(((EObject)assigned),featInsert.getTargetFeature(),value);
+				try {
+					dynamicFeatureAccess.insertDynamicFeatureValue(((EObject)assigned),featInsert.getTargetFeature(),value);
+				
+				} catch (ArrayStoreException e) {
+					BasicDiagnostic child = new BasicDiagnostic(
+							Diagnostic.ERROR,
+							MethodEvaluator.PLUGIN_ID,
+							0,
+							String.format("Cannot add the value to '%s': types mismatch", featInsert.getTargetFeature()),
+							new Object[] {featInsert.getTarget()}
+					);
+					diagnostic.add(child);
+					throw new CriticalFailure("Cannot add the value to '" + featInsert.getTargetFeature() + "': types mismatch", diagnostic);
+				}
 			}
 		}
 		return null;
@@ -271,7 +300,20 @@ public class MethodEvaluator {
 				}
 			}
 			else {
-				dynamicFeatureAccess.removeDynamicFeatureValue(((EObject)assigned),featRemove.getTargetFeature(),value);
+				try {
+					dynamicFeatureAccess.removeDynamicFeatureValue(((EObject)assigned),featRemove.getTargetFeature(),value);
+					
+				} catch (ArrayStoreException e) {
+					BasicDiagnostic child = new BasicDiagnostic(
+							Diagnostic.ERROR,
+							MethodEvaluator.PLUGIN_ID,
+							0,
+							String.format("Cannot remove the value from '%s': types mismatch", featRemove.getTargetFeature()),
+							new Object[] {featRemove.getTarget()}
+					);
+					diagnostic.add(child);
+					throw new CriticalFailure("Cannot remove the value from '" + featRemove.getTargetFeature() + "': types mismatch", diagnostic);
+				}
 			}
 		}
 		return null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -208,6 +208,9 @@ public class MethodEvaluator {
 					((List)variableValue).add(insertedValue);
 				}
 			}
+			else if(variableValue instanceof String) {
+				scope.put(varInsert.getName(), variableValue + "" + insertedValue);
+			}
 			else {
 				BasicDiagnostic child = new BasicDiagnostic(
 						Diagnostic.ERROR,
@@ -220,7 +223,6 @@ public class MethodEvaluator {
 				throw new CriticalFailure("Unable to insert a value in " + varInsert.getName(), diagnostic);
 			}
 		}
-		
 		return null;
 	}
 	
@@ -300,20 +302,7 @@ public class MethodEvaluator {
 				}
 			}
 			else {
-				try {
-					dynamicFeatureAccess.removeDynamicFeatureValue(((EObject)assigned),featRemove.getTargetFeature(),value);
-					
-				} catch (ArrayStoreException e) {
-					BasicDiagnostic child = new BasicDiagnostic(
-							Diagnostic.ERROR,
-							MethodEvaluator.PLUGIN_ID,
-							0,
-							String.format("Cannot remove the value from '%s': types mismatch", featRemove.getTargetFeature()),
-							new Object[] {featRemove.getTarget()}
-					);
-					diagnostic.add(child);
-					throw new CriticalFailure("Cannot remove the value from '" + featRemove.getTargetFeature() + "': types mismatch", diagnostic);
-				}
+				dynamicFeatureAccess.removeDynamicFeatureValue(((EObject)assigned),featRemove.getTargetFeature(),value);
 			}
 		}
 		return null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/AstBuilder.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/AstBuilder.java
@@ -117,6 +117,11 @@ public class AstBuilder {
 				while(topPkg.getESuperPackage() != null){
 					topPkg = topPkg.getESuperPackage();
 				}
+				// TODO Check whether qryEnv.removeEPackage(topPkg) should be called before
+				// 		There is a show stopper preventing the package to be registered again
+				//		-- could it prevent package updates?
+				//		See: https://git.eclipse.org/c/acceleo/org.eclipse.acceleo.git/tree/query/plugins/org.eclipse.acceleo.query/src/org/eclipse/acceleo/query/runtime/impl/EPackageProvider.java#n265
+				//			 (commit 	41f1588)
 				qryEnv.registerEPackage(topPkg);
 			});
 		

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -55,6 +55,8 @@ import org.eclipse.emf.ecoretools.ale.implementation.RuntimeClass;
 import org.eclipse.emf.ecoretools.ale.implementation.Statement;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableInsert;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.While;
 import org.eclipse.emf.ecoretools.ale.implementation.util.ImplementationSwitch;
 
@@ -375,6 +377,26 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 			EClassifierType declaredType = new EClassifierType(qryEnv, varDecl.getType());
 			lastScope.put(varDecl.getName(), Sets.newHashSet(declaredType));
 		}
+		
+		return null;
+	}
+	
+	@Override
+	public Object caseVariableInsert(VariableInsert insert) {
+		Map<String, Set<IType>> scope = getCurrentScope();
+		validateAndStore(insert.getValue(),scope);
+		
+		validators.stream().forEach(validator -> msgs.addAll(validator.validateVariableInsert(insert)));
+		
+		return null;
+	}
+	
+	@Override
+	public Object caseVariableRemove(VariableRemove remove) {
+		Map<String, Set<IType>> scope = getCurrentScope();
+		validateAndStore(remove.getValue(),scope);
+		
+		validators.stream().forEach(validator -> msgs.addAll(validator.validateVariableRemove(remove)));
 		
 		return null;
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -152,7 +152,7 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 			}
 		}
 		
-		Set<IType> selfTypeSet = new HashSet<IType>();
+		Set<IType> selfTypeSet = new HashSet<>();
 		EClassifierType selfType = new EClassifierType(qryEnv, xtdClass.getBaseClass());
 		selfTypeSet.add(selfType);
 		classScope.put("self", selfTypeSet);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidator.java
@@ -24,6 +24,8 @@ import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.emf.ecoretools.ale.implementation.RuntimeClass;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableInsert;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.While;
 
 public interface IValidator {
@@ -41,6 +43,8 @@ public interface IValidator {
 	public List<IValidationMessage> validateFeatureRemove(FeatureRemove featRemove);
 	public List<IValidationMessage> validateVariableAssignment(VariableAssignment varAssign);
 	public List<IValidationMessage> validateVariableDeclaration(VariableDeclaration varDecl);
+	public List<IValidationMessage> validateVariableInsert(VariableInsert varInsert);
+	public List<IValidationMessage> validateVariableRemove(VariableRemove varRemove);
 	public List<IValidationMessage> validateForEach(ForEach loop);
 	public List<IValidationMessage> validateIf(If ifStmt);
 	public List<IValidationMessage> validateWhile(While loop);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
@@ -40,6 +40,8 @@ import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.emf.ecoretools.ale.implementation.RuntimeClass;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableInsert;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.While;
 
 /**
@@ -507,6 +509,44 @@ public class NameValidator implements IValidator {
 			}
 		}
 		
+		return msgs;
+	}
+	
+	@Override
+	public List<IValidationMessage> validateVariableInsert(VariableInsert varInsert) {
+		List<IValidationMessage> msgs = new ArrayList<>();
+		
+		/*
+		 * Check name
+		 */
+		Set<IType> declaringTypes = base.getCurrentScope().get(varInsert.getName());
+		if(declaringTypes == null && !varInsert.getName().equals("result")){
+			msgs.add(new ValidationMessage(
+					ValidationMessageLevel.ERROR,
+					String.format(VARIABLE_UNDEFINED,varInsert.getName()),
+					base.getStartOffset(varInsert),
+					base.getEndOffset(varInsert)
+					));
+		}
+		return msgs;
+	}
+	
+	@Override
+	public List<IValidationMessage> validateVariableRemove(VariableRemove varRemove) {
+		List<IValidationMessage> msgs = new ArrayList<>();
+		
+		/*
+		 * Check name
+		 */
+		Set<IType> declaringTypes = base.getCurrentScope().get(varRemove.getName());
+		if(declaringTypes == null && !varRemove.getName().equals("result")){
+			msgs.add(new ValidationMessage(
+					ValidationMessageLevel.ERROR,
+					String.format(VARIABLE_UNDEFINED,varRemove.getName()),
+					base.getStartOffset(varRemove),
+					base.getEndOffset(varRemove)
+					));
+		}
 		return msgs;
 	}
 	

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/OpenClassValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/OpenClassValidator.java
@@ -31,6 +31,8 @@ import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.emf.ecoretools.ale.implementation.RuntimeClass;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableInsert;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.While;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -160,6 +162,16 @@ public class OpenClassValidator implements IValidator {
 
 	@Override
 	public List<IValidationMessage> validateVariableDeclaration(VariableDeclaration varDecl) {
+		return new ArrayList<>();
+	}
+	
+	@Override
+	public List<IValidationMessage> validateVariableInsert(VariableInsert varInsert) {
+		return new ArrayList<>();
+	}
+	
+	@Override
+	public List<IValidationMessage> validateVariableRemove(VariableRemove varRemove) {
 		return new ArrayList<>();
 	}
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -366,6 +366,22 @@ public class TypeValidator implements IValidator {
 						}
 					}
 				}
+				
+				// If both are Integers then we can insert the second one by adding its value to the first one
+				
+				if(int.class.equals(eDataType.getInstanceClass())) {
+					for(IType iType : possibleTypes) {
+						Object type = iType.getType();
+						// Match adding a primitive (e.g. a += 2)
+						if(Integer.class.equals(type)) {
+							return true;
+						}
+						// Match adding a variable (e.g. a += b)
+						if(type instanceof EDataType) {
+							return int.class.equals(((EDataType) type).getInstanceClass());
+						}
+					}
+				}
 			}
 		}
 		return false;

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
@@ -31,6 +31,7 @@ import org.eclipse.xtext.Keyword
 import org.eclipse.xtext.nodemodel.impl.HiddenLeafNode
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.validation.Check
+import org.eclipse.acceleo.query.runtime.ValidationMessageLevel
 
 /**
  * Delegate validation to ALE validator
@@ -73,11 +74,20 @@ class AleValidator extends AbstractAleValidator {
 		msgs.forEach[msg |
 			val marker = aleFile.createMarker(ALE_MARKER);
 			marker.setAttribute(IMarker.MESSAGE, msg.getMessage());
-			marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+			marker.setAttribute(IMarker.SEVERITY, severityOf(msg));
 			marker.setAttribute(IMarker.CHAR_START, msg.startPosition);
 			marker.setAttribute(IMarker.CHAR_END, msg.endPosition);
 		]
 		
+	}
+	
+	private def severityOf(IValidationMessage message) {
+		switch message.level {
+			case ValidationMessageLevel.INFO: IMarker.SEVERITY_INFO
+			case ValidationMessageLevel.WARNING: IMarker.SEVERITY_WARNING
+			case ValidationMessageLevel.ERROR: IMarker.SEVERITY_ERROR
+			default: ValidationMessageLevel.ERROR
+		}
 	}
 	
 	@Check


### PR DESCRIPTION
This PR fixes a few bugs related to the `+=` and `-=` operators.

### #53: Execution not stopping and not reporting error on += operator

The execution is now stopped in the following cases:

- `+=` is called on an object that is not a list, not a string and not an integer
- `-=` is called on an object that is not a list, not a string and not an integer
- `+=` is called on a list and the right operand cannot be added to the list because their types are incompatible

The type checker has also been enhanced and shows errors when:

- `+=` or `-=` is called on an inexisting variable
- `+=` or `-=` is called on `self`
- `+=` is called on a feature and the right operand cannot be added to the feature because their types are incompatible

The type checker still has flaws because it does not check the types of the operands when `+=` is called on a local variable (it would have taken too much time). In order to alleviate this I decided to show a warning:

![image](https://user-images.githubusercontent.com/25926433/64613064-8be44b00-d3d5-11e9-96b1-8abf5e4c257f.png)

### #55: += not working on Integer

`+=` and `-=` can now both be used on integers.

As a bonus, I also implemented `+=` for strings: the operator now performs a concatenation.

### Testing

Since I can't make tests pass on my own computer I was unable to both test the code and add new tests. I don't have the time to focus on fixing the tests so I propose this PR anyway and plan to create tests later. Would it be acceptable?