### PR TITLE
Prevent "couldn't find the 'result' variable" error

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and Obeo.
+ * Copyright (c) 2017-2019 Inria and Obeo.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -208,6 +208,8 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 	public Object caseMethod(Method mtd) {
 		Map<String,Set<IType>> methodScope = new HashMap<>(variableTypesStack.peek());
 		
+		// Add method's parameters to scope
+		
 		if(mtd.getOperationRef() != null) {
 			for (EParameter param : mtd.getOperationRef().getEParameters()) {
 				Set<IType> previousDeclaration = methodScope.get(param.getName());
@@ -215,6 +217,20 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 					EClassifierType type = new EClassifierType(qryEnv, param.getEType());
 					methodScope.put(param.getName(), Sets.newHashSet(type));
 				}
+			}
+		}
+		
+		// Add 'result' variable to scope
+
+		// May be false e.g. when the override keyword is used
+		// on a method that does not match any existing EOperation
+		boolean hasACorrespondingEOperation = mtd.getOperationRef() != null;
+		if (hasACorrespondingEOperation) {
+			EClassifier methodType = mtd.getOperationRef().getEType();
+			boolean returnsSomething = methodType != null;
+			if (returnsSomething) {
+				EClassifierType returnType = new EClassifierType(qryEnv, methodType);
+				methodScope.put("result", Sets.newHashSet(returnType));
 			}
 		}
 		

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignForbiddenValueToResult.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignForbiddenValueToResult.implem
@@ -1,0 +1,6 @@
+behavior test.declself;
+open class EClass {
+	def boolean foo() {
+		result := 'not a boolean';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/resultRead.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/resultRead.implem
@@ -1,0 +1,7 @@
+behavior test.declself;
+open class EClass {
+	def boolean foo() {
+		result := false;
+		('result is: ' + result);
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/BaseValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/BaseValidatorTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation.test;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.eclipse.emf.ecoretools.ale.core.validation.test.ValidationMessages.assertMsgEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.acceleo.query.runtime.IValidationMessage;
+import org.eclipse.acceleo.query.runtime.ValidationMessageLevel;
+import org.eclipse.emf.ecoretools.ale.ALEInterpreter;
+import org.eclipse.emf.ecoretools.ale.core.parser.Dsl;
+import org.eclipse.emf.ecoretools.ale.core.parser.DslBuilder;
+import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult;
+import org.eclipse.emf.ecoretools.ale.core.validation.ALEValidator;
+import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
+import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Check the behavior of a {@link BaseValidator}.
+ */
+public class BaseValidatorTest {
+	
+	ALEInterpreter interpreter;
+	
+	@Before
+	public void setup() {
+		interpreter = new ALEInterpreter();
+	}
+	
+	/**
+	 * Tests that the special 'result' variable can be read within a method's body.
+	 */
+	@Test
+	public void testResultVariableCanBeRead() {
+		Dsl environment = new Dsl(emptyList(), asList("input/validation/resultRead.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Tests that the type checker only allows to assign to 'result' a value which type
+	 * matches method's return type. 
+	 */
+	@Test
+	public void testTypeCheckingResultVariableAssignation() {
+		Dsl environment = new Dsl(emptyList(), asList("input/validation/assignForbiddenValueToResult.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 67, 92, "Expected [ecore::EBoolean] but was [java.lang.String]", msg.get(0));
+	}
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and Obeo.
+ * Copyright (c) 2017-2019 Inria and Obeo.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.validation.test;
 
+import static org.eclipse.emf.ecoretools.ale.core.validation.test.ValidationMessages.assertMsgEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -900,12 +901,5 @@ public class NameValidatorTest {
 		assertEquals(2, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 112, 117, "Feature wrong not found in EClass EClass", msg.get(0));
 		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 118, "Expected [ecore::EInt] but was [Nothing(Feature wrong not found in EClass EClass)]", msg.get(1));
-	}
-	
-	private void assertMsgEquals(ValidationMessageLevel errorLvl, int startPos, int endPos, String text, IValidationMessage msg){
-		assertEquals(errorLvl, msg.getLevel());
-		assertEquals(startPos, msg.getStartPosition());
-		assertEquals(endPos, msg.getEndPosition());
-		assertEquals(text, msg.getMessage());
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and Obeo.
+ * Copyright (c) 2017-2019 Inria and Obeo.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.validation.test;
 
+import static org.eclipse.emf.ecoretools.ale.core.validation.test.ValidationMessages.assertMsgEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -118,12 +119,5 @@ public class OpenClassValidationTest {
 	private EObject create(String className) {
 		EClassifier cls = interpreter.getQueryEnvironment().getEPackageProvider().getTypes(className).iterator().next();
 		return EcoreUtil.create((EClass) cls);
-	}
-	
-	private void assertMsgEquals(ValidationMessageLevel errorLvl, int startPos, int endPos, String text, IValidationMessage msg){
-		assertEquals(errorLvl, msg.getLevel());
-		assertEquals(startPos, msg.getStartPosition());
-		assertEquals(endPos, msg.getEndPosition());
-		assertEquals(text, msg.getMessage());
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and Obeo.
+ * Copyright (c) 2017-2019 Inria and Obeo.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.validation.test;
 
+import static org.eclipse.emf.ecoretools.ale.core.validation.test.ValidationMessages.assertMsgEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -1392,10 +1393,4 @@ public class TypeValidatorTest {
 		assertMsgEquals(ValidationMessageLevel.ERROR, 100, 132, "Expected [Collection(?)] but was [ecore::EClass]", msg.get(0));
 	}
 	
-	private void assertMsgEquals(ValidationMessageLevel errorLvl, int startPos, int endPos, String text, IValidationMessage msg){
-		assertEquals(errorLvl, msg.getLevel());
-		assertEquals(startPos, msg.getStartPosition());
-		assertEquals(endPos, msg.getEndPosition());
-		assertEquals(text, msg.getMessage());
-	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/ValidationMessages.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/ValidationMessages.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.acceleo.query.runtime.IValidationMessage;
+import org.eclipse.acceleo.query.runtime.ValidationMessageLevel;
+
+/**
+ * Provides utility methods for testing purposes. 
+ */
+final class ValidationMessages {
+	
+	private ValidationMessages() {
+		// utility classes should not be instantiated
+	}
+	
+	static void assertMsgEquals(ValidationMessageLevel errorLvl, int startPos, int endPos, String text, IValidationMessage msg){
+		assertEquals("wrong error level", errorLvl, msg.getLevel());
+		assertEquals("wrong start position", startPos, msg.getStartPosition());
+		assertEquals("wrong end position", endPos, msg.getEndPosition());
+		assertEquals("wrong message", text, msg.getMessage());
+	}
+
+}


### PR DESCRIPTION
Fix #40.

The type checker was unaware of the `result` variable and was hence providing irrelevant errors when reading it.

Fixed the issue by programmatically adding a `result` variable to the stack when entering a method scope (the exact same thing is already done for `self`). This variable has the same type as the `EOperation` thus allowing the type checker to perform well.

<div align="left">
<img src="https://user-images.githubusercontent.com/25926433/66901954-0d944d80-f000-11e9-89e4-a2caa800d256.png"/>
</div>
