### PR TITLE
Opening a class that does not exist should raise an error

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/OpenClassValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/OpenClassValidator.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.validation;
 
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.emf.ecoretools.ale.core.validation.QualifiedNames.getQualifiedName;
 
 import java.util.ArrayList;
@@ -46,6 +47,9 @@ public class OpenClassValidator implements IValidator {
 	public static final String OPENCLASS_DUPLICATION = "The EClass %s is already opened (need explicit extends)";
 	public static final String EXTENDS_ORDER = "The extended EClass %s have to be after %s";
 	public static final String NOT_AN_OPENABLE_CLASS = "Cannot open class %s: the class must be defined in an Ecore metamodel";
+	public static final String OPENED_CLASS_HAS_NAMESAKE = "Opening %s, which has namesakes. Make sure you're opening the right class.\n" +
+														   " - Opened: %s\n" +
+														   " - Namesakes: %s";
 	
 	BaseValidator base;
 	List<ExtendedClass> duplicatedExensions = new ArrayList<>();
@@ -104,15 +108,9 @@ public class OpenClassValidator implements IValidator {
 		}
 		EClass base = xtdClass.getBaseClass();
 		
-		boolean baseClassIsNotDefinedInAMetamodel = EClassifier.class.equals(base.getInstanceClass());
-		if (baseClassIsNotDefinedInAMetamodel) {
-			msgs.add(new ValidationMessage(
-					ValidationMessageLevel.ERROR,
-					String.format(NOT_AN_OPENABLE_CLASS, xtdClass.getName()),
-					this.base.getStartOffset(xtdClass),
-					this.base.getStartOffset(xtdClass) + "open class ".length() + xtdClass.getName().length()
-			));
-		}
+		validateExtendedClassHasNoNamesake(xtdClass, msgs);
+		validateExtendedClassExists(xtdClass, base, msgs);
+		
 		EList<EClass> superTypes = base.getESuperTypes();
 		List<EClass> extendsBaseClasses =
 			xtdClass
@@ -138,6 +136,36 @@ public class OpenClassValidator implements IValidator {
 		}
 		
 		return msgs;
+	}
+
+	private void validateExtendedClassExists(ExtendedClass xtdClass, EClass base, List<IValidationMessage> msgs) {
+		boolean baseClassDoesntExist = EClassifier.class.equals(base.getInstanceClass());
+		if (baseClassDoesntExist) {
+			msgs.add(new ValidationMessage(
+					ValidationMessageLevel.ERROR,
+					String.format(NOT_AN_OPENABLE_CLASS, xtdClass.getName()),
+					this.base.getStartOffset(xtdClass),
+					this.base.getStartOffset(xtdClass) + "open class ".length() + xtdClass.getName().length()
+			));
+		}
+	}
+
+	private void validateExtendedClassHasNoNamesake(ExtendedClass xtdClass, List<IValidationMessage> msgs) {
+		Collection<EClassifier> potentialNamesakes = this.base.qryEnv.getEPackageProvider().getTypes(xtdClass.getName());
+		Collection<String> namesakes = potentialNamesakes
+												  .stream()
+												  .filter(classi -> !classi.getEPackage().equals(xtdClass.getBaseClass().getEPackage()))
+												  .map(QualifiedNames::getQualifiedName)
+												  .collect(toList());
+		
+		if (!namesakes.isEmpty()) {
+			msgs.add(new ValidationMessage(
+					ValidationMessageLevel.WARNING,
+					String.format(OPENED_CLASS_HAS_NAMESAKE, xtdClass.getName(), getQualifiedName(xtdClass.getBaseClass().getEPackage()), namesakes),
+					this.base.getStartOffset(xtdClass),
+					this.base.getEndOffset(xtdClass)
+			));
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/QualifiedNames.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/QualifiedNames.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation;
+
+import static java.util.stream.Collectors.joining;
+
+import java.util.LinkedList;
+
+import org.eclipse.acceleo.query.validation.type.EClassifierType;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EPackage;
+
+/**
+ * Utility methods to compute qualified names. 
+ */
+final class QualifiedNames {
+	
+	private QualifiedNames() {
+		// utility class should not be instantiated
+	}
+
+	public static String getQualifiedName(EClassifier cls) {
+		return getQualifiedName(cls.getEPackage()) + "::" + cls.getName(); 
+	}
+	
+	public static String getQualifiedName(EPackage pkg) {
+		LinkedList<EPackage> pkgs = new LinkedList<>();
+		EPackage current = pkg;
+		while(current != null) {
+			pkgs.addFirst(current);
+			current = current.getESuperPackage();
+		}
+		return pkgs.stream()
+				   .map(p -> p.getName())
+				   .collect(joining("::"));
+	}
+	
+	public static String getQualifiedName(IType type) {
+		if(type instanceof EClassifierType) {
+			EClassifier cls = ((EClassifierType) type).getType();
+			return getQualifiedName(cls);
+		}
+		return type.toString();
+	}
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and Obeo.
+ * Copyright (c) 2017-2019 Inria and Obeo.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package org.eclipse.emf.ecoretools.ale.core.validation;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static org.eclipse.emf.ecoretools.ale.core.validation.QualifiedNames.getQualifiedName;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -924,33 +925,5 @@ public class TypeValidator implements IValidator {
 		}
 		
 		return res;
-	}
-	
-	private static String getQualifiedName(EClassifier cls) {
-		return getQualifiedName(cls.getEPackage()) + "::" + cls.getName(); 
-	}
-	
-	private static String getQualifiedName(EPackage pkg) {
-		LinkedList<EPackage> pkgs = new LinkedList<>();
-		EPackage current = pkg;
-		while(current != null) {
-			pkgs.addFirst(current);
-			current = current.getESuperPackage();
-		}
-		
-		return pkgs
-			.stream()
-			.map(p -> p.getName())
-			.collect(joining("::"));
-	}
-	
-	private static String getQualifiedName(IType type) {
-		
-		if(type instanceof EClassifierType) {
-			EClassifier cls = ((EClassifierType) type).getType();
-			return getQualifiedName(cls);
-		}
-		
-		return type.toString();
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/openingLocallyDefinedRuntimeClass.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/openingLocallyDefinedRuntimeClass.implem
@@ -1,0 +1,9 @@
+behavior test.assignfeat;
+
+open class LocalRuntimeClass {
+
+}
+
+class LocalRuntimeClass {
+
+ }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/openingNonExistingClass.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/openingNonExistingClass.implem
@@ -1,0 +1,5 @@
+behavior test.assignfeat;
+
+open class NonExisting {
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.emf.ecoretools.ale.core.validation.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -113,6 +114,31 @@ public class OpenClassValidationTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(0, msg.size());
+	}
+	
+	@Test
+	public void testOpeningNonExistingClass() {
+		Dsl environment = new Dsl(Arrays.asList("model/abc.ecore"),Arrays.asList("input/validation/openingNonExistingClass.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 27, 49, "Cannot open class NonExisting: the class must be defined in an Ecore metamodel", msg.get(0));
+	}
+	
+	@Test
+	public void testOpeningLocallyDefinedRuntimeClass() {
+		Dsl environment = new Dsl(Arrays.asList("model/abc.ecore"),Arrays.asList("input/validation/openingLocallyDefinedRuntimeClass.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertTrue("Opening a locally defined class should not raise any error", msg.isEmpty());
 	}
 	
 	private EObject create(String className) {

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
@@ -126,7 +126,7 @@ public class OpenClassValidationTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 27, 49, "Cannot open class NonExisting: the class must be defined in an Ecore metamodel", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 29, 51, "Cannot open class NonExisting: the class must be defined in an Ecore metamodel", msg.get(0));
 	}
 	
 	@Test


### PR DESCRIPTION
Fix #19.

### 1. Enhance the type checker to show an error when opening a class that does not exist:

```
behavior helloworld;

open class Foo {

}
```
Here, `Foo` can be:
 - a static class defined within an Ecore metamodel,
 - a runtime class defined in the same _.ale_ file,
 - a runtime class defined in another _.ale_ file.

Otherwise, an error is shown.

### 2. Enhance the type checker to show a warning when opening a class that has namesakes

```
behavior helloworld;

open class Foo {

}
```
Will raise a warning if a class `Foo` is defined:
 - in a package not called `helloworld`,
 - in an _.ale_ file which behavior is not `helloworld`

![image](https://user-images.githubusercontent.com/25926433/66923021-6bd52680-f028-11e9-982e-1b444f7411d5.png)
