### PR TITLE
[Type Checker] Refactor duplicated code

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ParseResult.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ParseResult.java
@@ -37,6 +37,7 @@ public class ParseResult<T> {
 	}
 	
 	public Map<Object, Integer> getEndPositions() {
+		// FIXME It looks like some end position are missing the last character in source code
 		return endPositions;
 	}
 	

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -62,6 +62,9 @@ import org.eclipse.emf.ecoretools.ale.implementation.util.ImplementationSwitch;
 
 import com.google.common.collect.Sets;
 
+/**
+ * Visits an ALE program's AST delegating validation of each element to given {@link IValidator validators}. 
+ */
 public class BaseValidator extends ImplementationSwitch<Object> {
 
 	List<IValidationMessage> msgs;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IAstLookup.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IAstLookup.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation;
+
+import java.util.Set;
+
+import org.eclipse.acceleo.query.ast.Expression;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecoretools.ale.implementation.Method;
+import org.eclipse.emf.ecoretools.ale.implementation.Statement;
+
+/**
+ * Used to retrieve the types of expressions manipulated by ALE.
+ */
+public interface IAstLookup {
+	
+	/**
+	 * Infers the types of a given expression.
+	 * 
+	 * @param expression
+	 * 			The expression which types must be inferred
+	 * 
+	 * @return the types inferred for the given expression
+	 */
+	Set<IType> inferredTypesOf(Expression expression);
+	
+	/**
+	 * Determines the types used to declare a variable.
+	 * 
+	 * @param variableName
+	 * 			The name of the variable to check
+	 * @param astBranch
+	 * 			A branch of the AST from which types will be looked for
+	 * 
+	 * @return the types found for the given variable
+	 */
+	Set<IType> typesDeclaredFor(String variableName, EObject astBranch);
+	
+	/**
+	 * Determines all the possible types of a feature.
+	 * 
+	 * @param featureName
+	 * 			The name of the feature
+	 * @param featureAccessExpression
+	 * 			The expression representing the access to the feature
+	 * 
+	 * @return all the possible types of the feature
+	 */
+	Set<IType> findFeatureTypes(String featureName, Expression featureAccessExpression);
+	
+	/**
+	 * Determines the method that surrounds a statement.
+	 * 
+	 * @param statement
+	 * 			The statement to check
+	 * 
+	 * @return the method enclosing the given statement
+	 */
+	// TODO [Refactor] Consider returning Optional<Method>
+	Method enclosingMethod(Statement statement);
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IConvertType.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IConvertType.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation;
+
+import java.util.Optional;
+
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.acceleo.query.validation.type.NothingType;
+import org.eclipse.acceleo.query.validation.type.SequenceType;
+import org.eclipse.acceleo.query.validation.type.SetType;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.ETypedElement;
+import org.eclipse.emf.ecore.EcorePackage;
+
+/**
+ * Performs conversions between AQL's {@link IType} and EMF's {@link EClassifier}.
+ */
+public interface IConvertType {
+	
+	/**
+	 * Turns an EMF typed element into an AQL type.
+	 * <p>
+	 * <h3>Type matching</h3>
+	 * <ul>
+	 * 	<li>{@link EcorePackage#getEEList() EEList} are turned into {@link SequenceType},
+	 * 	<li>{@link EStructuralFeature} with multiplicity "many" are turned into {@link SequenceType}, 
+	 * 	<li>{@link EStructuralFeature} with multiplicity "one" are turned into {@link SetType},
+	 * </ul>
+	 * For others, return {@link #toAQL(EClassifier) toAQL(typedElement.getEType())}.
+	 * <p>
+	 * <h3>Genericity</h3>
+	 * 
+	 * If the new type should have a generic parameter type but it cannot be resolved, 
+	 * {@link NothingType NothingType("?")} is used instead.
+	 * 
+	 * @param typedElement
+	 * 			The EMF element to convert to AQL
+	 * 
+	 * @return the AQL type corresponding to the given EMF type
+	 */
+	IType toAQL(ETypedElement typedElement);
+	
+	/**
+	 * Turns an EMF classifier into an AQL type.
+	 * <p>
+	 * If the classifier is turned into a generic type, such as {@link SequenceType},
+	 * its generic type parameter won't be resolved. For this reason you should use 
+	 * {@link #toAQL(EClassifier, EClassifier)} whenever possible.
+	 * 
+	 * @param type
+	 * 			The EMF classifier to convert
+	 * 
+	 * @return the AQL type corresponding to the given EMF classifier
+	 * 
+	 * @see #toAQL(EClassifier, EClassifier)
+	 */
+	IType toAQL(EClassifier type);
+	
+	/**
+	 * Turns an EMF classifier into an AQL type.
+	 * 
+	 * @param type
+	 * 			The EMF classifier to convert
+	 * @param typeParameter
+	 * 			The EMF generic type parameter or null if the type is not generic
+	 * 
+	 * @return the AQL type corresponding to the given EMF classifier
+	 * 
+	 * @see #toAQL(EClassifier)
+	 */
+	IType toAQL(EClassifier type, EClassifier typeParameter);
+
+	/**
+	 * Attempts to turn an AQL type into an EMF classifier.
+	 * 
+	 * @param type
+	 * 			The AQL type to convert
+	 * 
+	 * @return the EMF classifier corresponding to the given AQL type
+	 * 		   if able to convert it
+	 */
+	Optional<EClassifier> toEMF(IType type);
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.acceleo.query.ast.Expression;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.emf.ecore.EClassifier;
+
+/**
+ * Used to check properties about types manipulated by ALE.
+ */
+/**
+ * @author echebbi
+ *
+ */
+public interface ITypeChecker {
+
+	/**
+	 * Returns all the types that can be inserted into a variable of given types.
+	 * <p>
+	 * <b><u>Important</b></u>: the returned set may not be comprehensive! For instance,
+	 * if both {@code String} and {@code EString} are accepted then only one of these may
+	 * be returned.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable into which a value should be inserted
+	 * 
+	 * @return the types of the values that can be inserted into a variable
+	 * 		   of the given types.
+	 */
+	Set<IType> acceptedTypesForInsertion(Set<IType> variableTypes);
+
+	/**
+	 * Returns all the types that can be removed from a variable of given types.
+	 * <p>
+	 * <b><u>Important</b></u>: the returned set may not be comprehensive! For instance,
+	 * if both {@code Integer} and {@code EInt} are accepted then only one of these may
+	 * be returned.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable into which a value should be removed
+	 * 
+	 * @return the types of the values that can be removed from a variable
+	 * 		   of the given types.
+	 */
+	Set<IType> acceptedTypesForRemoval(Set<IType> variableTypes);
+	
+	/**
+	 * Determines whether a value of given types can be inserted to a variable of another types.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable to which a value could be inserted
+	 * @param valueTypes
+	 * 			The types of the value to insert
+	 * 
+	 * @return true if a value of a given types can be inserted to a variable of another types
+	 */
+	boolean acceptsInsertion(Set<IType> variableTypes, Set<IType> valueTypes);
+	
+	/**
+	 * Determines whether a value of a given types can be removed from a variable of another types.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable from which a value could be removed
+	 * @param valueTypes
+	 * 			The types of the value to remove
+	 * 
+	 * @return true if a value of a given types can be removed from a variable of another types
+	 */
+	boolean acceptsRemoval(Set<IType> variableTypes, Set<IType> valueTypes);
+	
+	/**
+	 * Determines whether a given element is allowed to belong to a collection.
+	 * <p>
+	 * In other words, determines whether the type of the element can be assigned
+	 * to the type of the collection's elements.
+	 * 
+	 * @param collectionType
+	 * 			The type of the collection to check
+	 * @param elementType
+	 * 			The type of the element that may belong to the collection
+	 * 
+	 * @return true if the element type is compatible with the collection, false otherwise
+	 */
+	boolean elementCanBelongToCollection(IType collectionType, IType elementType);
+	
+	/**
+	 * Finds a value type that is assignable to given variable type. 
+	 * 
+	 * @param variableType
+	 * 			The type of the variable to be assigned
+	 * @param valueTypes
+	 * 			The possible types of the value to assign
+	 * 
+	 * @return an assignable value type, if any
+	 */
+	Optional<IType> findCompatibleType(IType variableType, Set<IType> valueTypes);
+	
+	/**
+	 * Determines whether a type can be assigned to another type. 
+	 * <p>
+	 * This function is required because {@link IType#isAssignableFrom(IType)} does not work as expected
+	 * when its parameter represents a metaclass defined within user's metamodel. Reasons are the following:
+	 * <ul>
+	 * 	<li>when the package is registered, EMF does not register the type as a subtype of EClass. This is
+	 * 		likely expected since not explicitly stated in the metamodel, but still surprising. Hence, given:
+	 * 		<ul>
+	 * 			<li>target = EClass
+	 * 			<li>value = Greet (a custom EClass)
+	 * 		</ul>
+	 * 		Acceleo is not able to determine that Greet inherits from EClass and returns false when 
+	 * 		{@code target.isAssignableFrom(value)} is called.
+	 * 
+	 * 	<li>when no corresponding Java class is registered for the user class (which happens at least when 
+	 * 		the user has defined a metamodel but didn't generate any code) then the method returns true most
+	 *      of the time. That's because, since Acceleo is not able to determine that user's class inherits internally the algorithm is close to:
+	 * 		<pre>boolean isAssignableFrom(otherType) {
+	 *    if (getJavaClass(otherType) == null) {
+	 *        return this.isAssignable(null); 
+	 *    }
+	 *    return getJavaClass(this).isAssignableFrom(getJavaClass(otherType);
+	 *}</pre>
+	 * </ul>
+	 * <p>
+	 * Moreover, type parameters are not taken into account when comparing collections.
+	 * <p>
+	 * This method performs checks corresponding to the previous cases then calls {@link IType#isAssignableFrom(IType)}.
+	 * 
+	 * @param variable
+	 * 			The type to which a value should be assigned
+	 * @param valueType
+	 * 			The type of the expression to assign
+	 * 
+	 * @return whether a value of type {@code valueType} can be assigned to a variable of type {@code target}
+	 * 
+	 * @see #isAssignable(IType, Set)
+	 */
+	boolean isAssignable(IType variableType, IType valueType);
+
+	/**
+	 * Determines whether at least one type among a set can be assigned to another type.
+	 * 
+	 * @param variableType
+	 * 			The type to which a value should be assigned
+	 * @param valueTypes
+	 * 			The possible types of the expression to assign
+	 * 
+	 * @return true if at least one of value types can be assigned to the variable type
+	 * 
+	 * @see #isAssignable(IType, IType)
+	 */
+	boolean isAssignable(IType variableType, Set<IType> valueTypes);
+	
+	/**
+	 * Determines whether an expression yields a boolean value.
+	 * 
+	 * @param expression
+	 * 			The expression to check.
+	 * 
+	 * @return true if the expression yields a boolean value, false otherwise
+	 */
+	boolean isBoolean(Expression expression);
+	
+	/**
+	 * Determines whether the given type corresponds to a boolean.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type represents a boolean, false otherwise
+	 */
+	boolean isBoolean(IType type);
+	
+	/**
+	 * Determines whether the given type corresponds to a collection.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type represents a collection, false otherwise
+	 */
+	boolean isCollection(IType type);
+	
+	/**
+	 * Determines whether the given type corresponds to an integer.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type represents an integer, false otherwise
+	 */
+	boolean isInteger(IType type);
+
+	/**
+	 * Determines whether the given type corresponds to a string.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type represents a string, false otherwise
+	 */
+	boolean isString(IType type);
+	
+	/**
+	 * Determines whether the type is known.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return false if the type is known, true otherwise
+	 */
+	boolean isUnknown(IType type);
+
+	/**
+	 * Determines whether the type has been resolved.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return false is the type has been resolved, true otherwise
+	 */
+	boolean isUnresolved(EClassifier type);
+	
+	/**
+	 * Determines whether a type supports the '+=' operator.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type supports the '+=' operator, false otherwise
+	 * 
+	 * @see #supportsRemoval(IType)
+	 */
+	boolean supportsInsertion(IType type);
+
+	/**
+	 * Determines whether a type supports the '-=' operator.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type supports the '-=' operator, false otherwise
+	 * 
+	 * @see #supportsInsertion(IType)
+	 */
+	boolean supportsRemoval(IType type);
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidationMessageFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidationMessageFactory.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation;
+
+import java.util.Set;
+
+import org.eclipse.acceleo.query.ast.Expression;
+import org.eclipse.acceleo.query.runtime.IValidationMessage;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
+import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
+import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
+
+/**
+ * A factory that creates new, tailored, {@link IValidationMessage validation messages}.
+ * <p>
+ * A lot of methods need a reference to an AST element. This element is used to set the position
+ * of the message in the corresponding source code.
+ * <p>
+ * <b>Important</b>: this interface is for internal use only and should not be used by clients.
+ */
+public interface IValidationMessageFactory {
+	
+	/**
+	 * Creates a message warning about the assignment to the 'result'
+	 * variable within a void operation.
+	 * 
+	 * @param assignment
+	 * 			The assignment to 'result'
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage assignmentToResultInVoidOperation(VariableAssignment assignment);
+	
+	/**
+	 * Creates a message telling that an expression was supposed to be boolean.
+	 * 
+	 * @param exp
+	 * 			The non-boolean expression
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage expectedBoolean(Expression exp);
+	
+	/**
+	 * Creates a message warning about a class extending itself.
+	 * 
+	 * @param xtdClass
+	 * 			The class that extends itself.
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage extendingItself(ExtendedClass xtdClass);
+	
+	/**
+	 * Creates a message warning about an attempt to iterate over a scalar
+	 * with a for each loop.
+	 * 
+	 * @param loop
+	 * 			The for each statement
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage forEachCanOnlyIterateOnCollections(ForEach loop);
+	
+	/**
+	 * Creates a message warning about an attempt to assign a value to a variable
+	 * of a non compatible type.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable
+	 * @param valueTypes
+	 * 			The types of the value
+	 * @param assignment
+	 * 			The assignment statement
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage illegalAssignment(Set<IType> variableTypes, Set<IType> valueTypes, Object assignment);
+	
+	/**
+	 * Creates a message warning about an attempt to insert a value into a variable
+	 * of a non compatible type.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable
+	 * @param insertedValueTypes
+	 * 			The types of the value to insert
+	 * @param acceptedValueTypes
+	 * 			The types that are compatible for an insertion to the variable
+	 * @param value
+	 * 			The value to insert
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage illegalInsertion(Set<IType> variableTypes, Set<IType> insertedValueTypes, Set<IType> acceptedValueTypes, Object value);
+	
+	/**
+	 * Creates a message warning about an attempt to remove a value from a variable
+	 * of a non compatible type.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable
+	 * @param removedValueTypes
+	 * 			The types of the value to removed
+	 * @param acceptedValueTypes
+	 * 			The types that are compatible for an insertion to the variable
+	 * @param value
+	 * 			The value to remove
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage illegalRemoval(Set<IType> variableTypes, Set<IType> removedValueTypes, Set<IType> acceptedValueTypes, Object value);
+	
+	/**
+	 * Creates a message warning about unexpected types.
+	 * 
+	 * @param att
+	 * 			The attribute having the expected types
+	 * @param actualTypes
+	 * 			The actual, unexpected types
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage incompatibleTypes(Attribute att, Set<IType> actualTypes);
+	
+	/**
+	 * Creates a message warning about unexpected types.
+	 * 
+	 * @param expected
+	 * 			The expected types
+	 * @param actual
+	 * 			The actual, unexpected types
+	 * @param statement
+	 * 			The statement where the unexpected types have been found
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage incompatibleTypes(Set<IType> expected, Set<IType> actual, Object statement);
+	
+	/**
+	 * Creates a message warning about an attempt to extend a class that is not 
+	 * a direct super type of self.
+	 * 
+	 * @param xtdClass
+	 * 			The extending class
+	 * @param superBase
+	 * 			The extended class
+	 * @param baseCls
+	 * 			The parent class of extending class
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage indirectExtension(ExtendedClass xtdClass, EClass superBase, EClass baseCls);
+	
+	/**
+	 * Creates a message warning about an attempt to insert a value into 'self'.
+	 * 
+	 * @param statement
+	 * 			The insertion statement
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage prohibitedInsertionToSelf(Object statement);
+
+	/**
+	 * Creates a message warning about an attempt to remove a value from 'self'.
+	 * 
+	 * @param statement
+	 * 			The remove statement
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage prohibitedRemovalFromSelf(Object statement);
+
+	/**
+	 * Creates a message warning about the use of a variable which type
+	 * could not being resolved.
+	 * 
+	 * @param expression
+	 * 			The expression where the variable is used
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage unresolvedType(Object expression);
+	
+	/**
+	 * Creates a message warning about the use of an operator on a feature
+	 * which type does not support it.
+	 * 
+	 * @param featureTypes
+	 * 			The types of the feature
+	 * @param statement
+	 * 			The statement in which the operator is used
+	 * @param featureName
+	 * 			The name of the feature on which the operator is used
+	 * @param operator
+	 * 			The operator
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage unsupportedOperatorOnFeature(Set<IType> featureTypes, Object statement, String featureName, String operator);
+	
+	/**
+	 * Creates a message warning about the use of an operator on a variable
+	 * which type does not support it.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable
+	 * @param statement
+	 * 			The statement in which the operator is used
+	 * @param variableName
+	 * 			The name of the variable on which the operator is used
+	 * @param operator
+	 * 			The operator
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage unsupportedOperatorOnVariable(Set<IType> variableTypes, Object statement, String variableName, String operator);
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IVariableModificationStrategy.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IVariableModificationStrategy.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+import org.eclipse.acceleo.query.runtime.IValidationMessage;
+import org.eclipse.acceleo.query.validation.type.IType;
+
+/**
+ * Represents a modification that can be applied to a variable/feature.
+ * <p>
+ * Convenient interface used internally by {@link TypeValidator}; it has been put
+ * in its own class to alleviate the code.
+ */
+interface IVariableModificationStrategy {
+
+	/**
+	 * Determines the scope of the modification.
+	 * @return true if the modification inserts a new value, false if it removes one.
+	 */
+	boolean isInsertion();
+	
+	/**
+	 * Determines all the types of the values that can be accepted as operand of the modification.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable targeted by the modification
+	 * 
+	 * @return the types of the values that can be used to modify the variable
+	 */
+	Set<IType> acceptedTypes(Set<IType> variableTypes);
+
+	/**
+	 * Determines whether a variable supports the modification.
+	 * 
+	 * @param variableType
+	 * 			The type of the variable
+	 * 
+	 * @return true if the variable supports the modification, false otherwise
+	 */
+	boolean supportsModification(IType variableType);
+
+	/**
+	 * Determines whether the modification can be applied on a variable using a given value.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable to modify
+	 * @param valueTypes
+	 * 			The types of the value used to modify the variable
+	 * 
+	 * @return true if the modification is allowed, false otherwise
+	 */
+	boolean acceptsModification(Set<IType> variableTypes, Set<IType> valueTypes);
+	
+	/**
+	 * Creates a message warning about an attempt to modify a variable with a value
+	 * having an incompatible type.
+	 * 
+	 * @param variableTypes
+	 * 			The types of the variable
+	 * @param removedValueTypes
+	 * 			The types of the value to removed
+	 * @param acceptedValueTypes
+	 * 			The types that are compatible for an insertion to the variable
+	 * @param valueExpression
+	 * 			The value used to modify the variable
+	 * 
+	 * @return a new validation message
+	 */
+	IValidationMessage createIllegalModificationMessage(Set<IType> variableTypes, Set<IType> valueTypes, Set<IType> acceptedValueTypes, Object valueExpression);
+}
+
+/**
+ * Represents the insertion of a value (the '+=' operator). 
+ */
+class InsertionStrategy implements IVariableModificationStrategy {
+
+	private final ITypeChecker typeChecker;
+
+	private final IValidationMessageFactory messages;
+	
+	/**
+	 * Creates a new modification strategy representing the insertion of a value (the '+=' operator).
+	 * 
+	 * @param typeChecker
+	 * 			The instance used to check the types of variables
+	 * @param messages
+	 * 			The factory used to create validation messages
+	 */
+	public InsertionStrategy(ITypeChecker typeChecker, IValidationMessageFactory messages) {
+		this.typeChecker = requireNonNull(typeChecker, "typeChecker");
+		this.messages = requireNonNull(messages, "messages");
+	}
+
+	@Override
+	public boolean isInsertion() {
+		return true;
+	}
+
+	@Override
+	public Set<IType> acceptedTypes(Set<IType> variableTypes) {
+		return typeChecker.acceptedTypesForInsertion(variableTypes);
+	}
+
+	@Override
+	public boolean supportsModification(IType variableType) {
+		return typeChecker.supportsInsertion(variableType);
+	}
+
+	@Override
+	public boolean acceptsModification(Set<IType> variableTypes, Set<IType> valueTypes) {
+		return typeChecker.acceptsInsertion(variableTypes, valueTypes);
+	}
+
+	@Override
+	public IValidationMessage createIllegalModificationMessage(Set<IType> variableTypes, Set<IType> valueTypes,
+			Set<IType> acceptedValueTypes, Object valueExpression) {
+		return messages.illegalInsertion(
+				variableTypes, valueTypes, acceptedValueTypes, valueExpression);
+	}
+
+}
+
+/**
+ * Represents the removal of a value (the '-='operator)
+ */
+class RemovalStrategy implements IVariableModificationStrategy {
+
+	private final ITypeChecker typeChecker;
+	
+	private final IValidationMessageFactory messages;
+
+	/**
+	 * Creates a new modification strategy representing the removal of a value (the '-=' operator).
+	 * 
+	 * @param typeChecker
+	 * 			The instance used to check the types of variables
+	 * @param messages
+	 * 			The factory used to create validation messages
+	 */
+	public RemovalStrategy(ITypeChecker typeChecker, IValidationMessageFactory messages) {
+		this.typeChecker = typeChecker;
+		this.messages = messages;
+	}
+
+	@Override
+	public boolean isInsertion() {
+		return false;
+	}
+
+	@Override
+	public Set<IType> acceptedTypes(Set<IType> variableTypes) {
+		return typeChecker.acceptedTypesForRemoval(variableTypes);
+	}
+
+	@Override
+	public boolean supportsModification(IType variableType) {
+		return typeChecker.supportsRemoval(variableType);
+	}
+
+	@Override
+	public boolean acceptsModification(Set<IType> variableTypes, Set<IType> valueTypes) {
+		return typeChecker.acceptsRemoval(variableTypes, valueTypes);
+	}
+
+	@Override
+	public IValidationMessage createIllegalModificationMessage(Set<IType> variableTypes, Set<IType> valueTypes,
+			Set<IType> acceptedValueTypes, Object valueExpression) {
+		return messages.illegalRemoval(
+				variableTypes, valueTypes, acceptedValueTypes, valueExpression);
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/QualifiedNames.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/QualifiedNames.java
@@ -14,21 +14,27 @@ import static java.util.stream.Collectors.joining;
 
 import java.util.LinkedList;
 
+import org.eclipse.acceleo.query.validation.type.AbstractCollectionType;
 import org.eclipse.acceleo.query.validation.type.EClassifierType;
 import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.acceleo.query.validation.type.SetType;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EPackage;
 
 /**
- * Utility methods to compute qualified names. 
+ * Utility methods to compute qualified names.
  */
-final class QualifiedNames {
+final public class QualifiedNames {
 	
 	private QualifiedNames() {
 		// utility class should not be instantiated
 	}
-
+	
 	public static String getQualifiedName(EClassifier cls) {
+		if (cls.getEPackage() == null) {
+			return cls.getInstanceClassName().isEmpty() ? cls.getName()
+														: cls.getInstanceClassName();
+		}
 		return getQualifiedName(cls.getEPackage()) + "::" + cls.getName(); 
 	}
 	
@@ -45,11 +51,19 @@ final class QualifiedNames {
 	}
 	
 	public static String getQualifiedName(IType type) {
+		if(type instanceof SetType) {
+			AbstractCollectionType collectionType = (AbstractCollectionType) type;
+			return "Set(" + getQualifiedName(collectionType.getCollectionType()) + ")";
+		}
+		if(type instanceof AbstractCollectionType) {
+			AbstractCollectionType collectionType = (AbstractCollectionType) type;
+			return "Collection(" + getQualifiedName(collectionType.getCollectionType()) + ")";
+		}
 		if(type instanceof EClassifierType) {
 			EClassifier cls = ((EClassifierType) type).getType();
 			return getQualifiedName(cls);
 		}
-		return type.toString();
+		return String.valueOf(type);
 	}
 	
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation.impl;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.acceleo.query.ast.Expression;
+import org.eclipse.acceleo.query.validation.type.AbstractCollectionType;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
+import org.eclipse.emf.ecoretools.ale.core.validation.IAstLookup;
+import org.eclipse.emf.ecoretools.ale.core.validation.IConvertType;
+import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
+import org.eclipse.emf.ecoretools.ale.implementation.BehavioredClass;
+import org.eclipse.emf.ecoretools.ale.implementation.Block;
+import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
+import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
+import org.eclipse.emf.ecoretools.ale.implementation.Method;
+import org.eclipse.emf.ecoretools.ale.implementation.Statement;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
+
+/**
+ * Used to retrieve types of expressions manipulated by ALE.
+ */
+public final class AstLookup implements IAstLookup {
+	
+	private final BaseValidator base;
+	
+	private final IConvertType convert;
+	
+	public AstLookup(BaseValidator base, IConvertType convert) {
+		this.base = requireNonNull(base, "base");
+		this.convert = requireNonNull(convert, "convert");
+	}
+	
+	@Override
+	public Set<IType> inferredTypesOf(Expression expression) {
+		Set<IType> inferredTypes = base.getPossibleTypes(expression);
+		if(inferredTypes == null) {
+			return new HashSet<>();
+		}
+		return inferredTypes;
+	}
+	
+	@Override
+	public Set<IType> typesDeclaredFor(String variableName, EObject astBranch) {
+		Set<IType> declaredTypes = new HashSet<>();
+		
+		// Look at extended EClass attributes
+		EObject currentObject = astBranch;
+		EObject currentScope = astBranch.eContainer();
+		
+		while(currentScope != null) {
+			
+			// Look at previous statement in the same block
+			if(currentScope instanceof Block) {
+				Block block = (Block) currentScope;
+				int index = block.getStatements().indexOf(currentObject);
+				if(index != -1) {
+					Optional<VariableDeclaration> candidate =
+						block.getStatements()
+						.stream()
+						.limit(index)
+						.filter(VariableDeclaration.class::isInstance)
+						.map(VariableDeclaration.class::cast)
+						.filter(varDecl -> varDecl.getName().equals(variableName))
+						.findFirst();
+					if(candidate.isPresent()) {
+						EClassifier type = candidate.get().getType();
+						EClassifier typeParameter = candidate.get().getTypeParameter();
+						declaredTypes.add(convert.toAQL(type, typeParameter));
+						return declaredTypes;
+					}
+				}
+			}
+			
+			// Look at loop's variable
+			else if(currentScope instanceof ForEach) {
+				ForEach loop = (ForEach) currentScope;
+				if(loop.getVariable().equals(variableName)) {
+					return base.getPossibleTypes(loop.getCollectionExpression()).stream()
+							   .map(AbstractCollectionType.class::cast)
+							   .map(AbstractCollectionType::getCollectionType)
+							   .collect(toSet());
+				}
+			}
+			
+			// Look at class extension
+			else if(currentScope instanceof BehavioredClass) {
+				BehavioredClass cls = (BehavioredClass) currentScope;
+				Optional<Attribute> candidate = cls.getAttributes().stream().filter(attr -> attr.getFeatureRef().getName().equals(variableName)).findFirst();
+				if(candidate.isPresent()) {
+					EClassifier type = candidate.get().getFeatureRef().getEType();
+					declaredTypes.add(convert.toAQL(type));
+					return declaredTypes;
+				}
+			}
+			
+			// Look at extended class
+			else if(currentScope instanceof ExtendedClass) {
+				ExtendedClass extension = (ExtendedClass) currentScope;
+				Optional<EStructuralFeature> feature = 
+						extension.getBaseClass().getEAllStructuralFeatures()
+						.stream()
+						.filter(feat -> feat.getName().equals(variableName))
+						.findFirst();
+				if(feature.isPresent()) {
+					EClassifier type = feature.get().getEType();
+					declaredTypes.add(convert.toAQL(type));
+					return declaredTypes;
+				}
+			}
+			currentObject = currentScope;
+			currentScope = currentScope.eContainer();
+		}
+		return declaredTypes;
+	}
+	
+	@Override
+	public Set<IType> findFeatureTypes(String featureName, Expression featureAccessExpression) {
+		Set<IType> variableTypes = new HashSet<>();
+		Set<IType> inferredVariableTypes = base.getPossibleTypes(featureAccessExpression);
+		
+		for(IType type : inferredVariableTypes){
+			if(type.getType() instanceof EClass){
+				EClass realType = (EClass) type.getType();
+				EStructuralFeature feature = realType.getEStructuralFeature(featureName);
+				
+				boolean featureIsCreatedAtRuntime = (feature == null);
+				if(featureIsCreatedAtRuntime) {
+					List<ExtendedClass> extensions = base.findExtensions(realType);
+					feature = extensions.stream()
+										.flatMap(xtdCls -> xtdCls.getAttributes().stream())
+										.filter(field -> field.getFeatureRef().getName().equals(featureName))
+										.map(Attribute::getFeatureRef)
+										.findAny().orElse(null);
+				}
+				if(feature == null) {
+					// The feature does not exist, the error will be handled by a NameValidator
+					// TODO Check if it is possible to have a non-existing feature here and consider
+					//		showing an error message if necessary
+					continue;
+				}
+				IType featureType = convert.toAQL(feature);
+				variableTypes.add(featureType);
+			}
+		}
+		return variableTypes;
+	}
+	
+	@Override
+	public Method enclosingMethod(Statement statement) {
+		EObject parent = statement.eContainer();
+		while(parent != null && !(parent instanceof Method)){
+			parent = parent.eContainer();
+		}
+		return (Method) parent;
+	}
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation.impl;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
+import org.eclipse.acceleo.query.runtime.IQueryEnvironment;
+import org.eclipse.acceleo.query.validation.type.EClassifierType;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.acceleo.query.validation.type.NothingType;
+import org.eclipse.acceleo.query.validation.type.SequenceType;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EGenericType;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.ETypedElement;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecoretools.ale.core.validation.IConvertType;
+
+public final class ConvertType implements IConvertType {
+	
+	private final IQueryEnvironment queryEnvironment;
+	
+	public ConvertType(IQueryEnvironment queryEnvironment) {
+		this.queryEnvironment = requireNonNull(queryEnvironment, "queryEnvironment");
+	}
+	
+	@Override
+	public IType toAQL(ETypedElement typedElement) {
+		if(typedElement.getEType() == EcorePackage.eINSTANCE.getEEList()) {
+			IType aqlGenericType = new NothingType("?");
+			if(!typedElement.getEGenericType().getETypeArguments().isEmpty()) {
+				EGenericType emfGenericType = typedElement.getEGenericType().getETypeArguments().get(0);
+				aqlGenericType = toAQL(emfGenericType.getEClassifier());
+			}
+			return new SequenceType(queryEnvironment, aqlGenericType);
+		}
+		if(typedElement instanceof EStructuralFeature) {
+			EStructuralFeature feature = (EStructuralFeature) typedElement;
+			if(feature.isMany()) {
+				// FIXME Unique is true by default so currently any feature is turned into a set; we should set it to false
+//				if(feature.isUnique()) {
+//					return new SetType(env, TypeConverter.toAQL(env, feature.getEType()));
+//				}
+//				else {
+					return new SequenceType(queryEnvironment, toAQL(feature.getEType()));
+//				}
+			}
+		}
+		return toAQL(typedElement.getEType());
+	}
+	
+	@Override
+	public IType toAQL(EClassifier type) {
+		return toAQL(type, null);
+	}
+	
+	@Override
+	public IType toAQL(EClassifier type, EClassifier typeParameter) {
+		if(type == EcorePackage.eINSTANCE.getEEList()) {
+			IType collectionType = new NothingType("?");
+			if(typeParameter != null) {
+				collectionType = toAQL(typeParameter);
+			}
+			return new SequenceType(queryEnvironment, collectionType);
+		}
+		return new EClassifierType(queryEnvironment, type);
+	}
+
+	@Override
+	public Optional<EClassifier> toEMF(IType type) {
+		 if(type.getType() instanceof EClassifier) {
+			 EClassifier classifier = (EClassifier) type.getType();
+			 return Optional.of(classifier);
+		 }
+		 return Optional.empty();
+	}
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
@@ -1,0 +1,279 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation.impl;
+
+import static com.google.common.collect.Sets.newHashSet;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.acceleo.query.ast.Expression;
+import org.eclipse.acceleo.query.validation.type.ClassType;
+import org.eclipse.acceleo.query.validation.type.ICollectionType;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.acceleo.query.validation.type.NothingType;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
+import org.eclipse.emf.ecoretools.ale.core.validation.ITypeChecker;
+import org.eclipse.emf.ecoretools.ale.implementation.ImplementationPackage;
+
+public final class TypeChecker implements ITypeChecker {
+	
+	private final BaseValidator base;
+	
+	public TypeChecker(BaseValidator base) {
+		this.base = base;
+	}
+	
+	@Override
+	public Set<IType> acceptedTypesForInsertion(Set<IType> variableTypes) {
+		Set<IType> acceptedTypes = new HashSet<>();
+		
+		for(IType variableType : variableTypes) {
+			if(isInteger(variableType)) {
+				acceptedTypes.add(variableType);
+			}
+			else if(isString(variableType)) {
+				acceptedTypes.add(variableType);
+			}
+			else if(variableType instanceof ICollectionType) {
+				ICollectionType collection = (ICollectionType) variableType;
+				if(collection.getCollectionType() != null) {
+					acceptedTypes.add(collection.getCollectionType());
+					acceptedTypes.add(collection);
+				}
+			}
+		}
+		return acceptedTypes;
+	}
+	
+	@Override
+	public Set<IType> acceptedTypesForRemoval(Set<IType> variableTypes) {
+		Set<IType> acceptedTypes = new HashSet<>();
+		
+		for(IType variableType : variableTypes) {
+			if(isInteger(variableType)) {
+				acceptedTypes.add(variableType);
+			}
+			else if(variableType instanceof ICollectionType) {
+				ICollectionType collection = (ICollectionType) variableType;
+				if(collection.getCollectionType() != null) {
+					acceptedTypes.add(collection.getCollectionType());
+					acceptedTypes.add(collection);
+				}
+			}
+		}
+		return acceptedTypes;
+	}
+	
+	@Override
+	public boolean acceptsInsertion(Set<IType> variableTypes, Set<IType> valueTypes) {
+		for (IType variableType : variableTypes) {
+			for (IType valueType : valueTypes) {
+				if(isInteger(variableType) && isInteger(valueType)) {
+					// addition
+					return true;
+				}
+				if(isString(variableType) && isString(valueType)) {
+					// string concatenation
+					return true;
+				}
+				if(isCollection(variableType) && elementCanBelongToCollection(variableType, valueType)) {
+					// addition of an element to a collection
+					return true;
+				}
+				if(isCollection(variableType) && isCollection(valueType) && isAssignable(variableType, valueType)) {
+					// collections concatenation
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean acceptsRemoval(Set<IType> variableTypes, Set<IType> valueTypes) {
+		for (IType variableType : variableTypes) {
+			for (IType valueType : valueTypes) {
+				if(isInteger(variableType) && isInteger(valueType)) {
+					// subtraction
+					return true;
+				}
+				if(isCollection(variableType) && elementCanBelongToCollection(variableType, valueType)) {
+					// removing an element from a collection
+					return true;
+				}
+				if(isCollection(variableType) && isCollection(valueType) && isAssignable(variableType, valueType)) {
+					// collections difference
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean elementCanBelongToCollection(IType collectionType, IType elementType) {
+		if(!(collectionType instanceof ICollectionType)) {
+			return false;
+		}
+		ICollectionType pcollectionType = (ICollectionType) collectionType;
+		return isAssignable(pcollectionType.getCollectionType(), newHashSet(elementType));
+	}
+	
+	@Override
+	public Optional<IType> findCompatibleType(IType variableType, Set<IType> valueTypes) {
+		return valueTypes.stream()
+						 .filter(inferredType -> isAssignable(variableType, inferredType))
+						 .findAny();
+	}
+	
+	@Override
+	public boolean isAssignable(IType variableType, IType valueType) {
+		// FIXME Check custom EClass somehow. The algorithm could be:
+		//			1. Check whether either targetType or valueType correspond to a class defined in user's metamodel
+		//			2. If yes, then somehow ensure types are coherent
+		//			3. If not, then delegate to IType#isAssignableFrom
+		//
+		// It could also worth considering adding EObject as a super type of user's classes to help IType doing its
+		// job well. This could be done in DslBuilder#register(List<EPackages>).
+		boolean bothAreCollections = isCollection(variableType) && isCollection(valueType);
+		if(bothAreCollections) {
+			return collectionsHaveCompatibleGenericTypes(variableType, valueType);
+		}
+		if(isBoolean(variableType) && isBoolean(valueType)) {
+			return true;
+		}
+		if(isInteger(variableType) && isInteger(valueType)) {
+			return true;
+		}
+		if(isString(variableType) && isString(valueType)) {
+			return true;
+		}
+		return variableType.isAssignableFrom(valueType);
+	}
+	
+	private boolean collectionsHaveCompatibleGenericTypes(IType variable, IType value) {
+		IType variableCollectionType = ((ICollectionType) variable).getCollectionType();
+		IType valueCollectionType = ((ICollectionType) value).getCollectionType();
+		
+		if(isUnknown(variableCollectionType)) {
+			// The variable has no generic type and can hence holds any Object.
+			// As such, any other collection is compatible with it.
+			return true;
+		}
+		if(isUnknown(valueCollectionType)) {
+			// The value has no generic type and can hence be assigned to any other collection
+			return true;
+		}
+		return isAssignable(variableCollectionType, valueCollectionType);
+	}
+	
+	@Override
+	public boolean isAssignable(IType variableType, Set<IType> valueTypes) {
+		return findCompatibleType(variableType, valueTypes).isPresent();
+	}
+
+	
+	@Override
+	public boolean isBoolean(Expression exp) {
+		Set<IType> expressionTypes = base.getPossibleTypes(exp);
+		return expressionTypes.stream()
+					   		  .anyMatch(type -> isBoolean(type));
+	}
+	
+	@Override
+	public boolean isBoolean(IType type) {
+		final IType booleanObjectType = new ClassType(base.getQryEnv(), Boolean.class);
+		final IType booleanType = new ClassType(base.getQryEnv(), boolean.class);
+		
+		return booleanObjectType.isAssignableFrom(type) || booleanType.isAssignableFrom(type);
+	}
+	
+	@Override
+	public boolean isCollection(IType type) {
+		return type instanceof ICollectionType;
+	}
+	
+	@Override
+	public boolean isInteger(IType type) {
+		// Match primitives, e.g. 42
+		if (Integer.class.equals(type.getType()) ) {
+			return true;
+		}
+		// Match variables of type Int
+		if (type.getType() instanceof EDataType) {
+			EDataType dataType = (EDataType) type.getType();
+			return int.class.equals(dataType.getInstanceClass())
+				|| Integer.class.equals(dataType.getInstanceClass());
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean isString(IType type) {
+		// Match primitives, e.g. 'hello'
+		if(String.class.equals(type.getType())) {
+			return true;
+		}
+		// Match primitives, e.g. 'hello'
+		if(type.getType() == EcorePackage.eINSTANCE.getEString()) {
+			return true;
+		}
+		// Match variables of type String
+		if(type.getType() instanceof EDataType) {
+			EDataType dataType = (EDataType) type.getType();
+			return String.class.equals(dataType.getInstanceClass());
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean isUnknown(IType type) {
+		return type == null || type instanceof NothingType;
+	}
+	
+	@Override
+	public boolean isUnresolved(EClassifier type) {
+		return type == ImplementationPackage.eINSTANCE.getUnresolvedEClassifier();
+	}
+
+	@Override
+	public boolean supportsInsertion(IType type) {
+		if(isCollection(type)) {
+			return true;
+		}
+		if(isInteger(type)) {
+			return true;
+		}
+		if(isString(type)) {
+			return true;
+		}
+		// FIXME handle other numbers
+		return false;
+	}
+	
+	@Override
+	public boolean supportsRemoval(IType type) {
+		if(isCollection(type)) {
+			return true;
+		}
+		if(isInteger(type)) {
+			return true;
+		}
+		// FIXME handle other numbers
+		return false;
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ValidationMessageFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ValidationMessageFactory.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation.impl;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static org.eclipse.emf.ecoretools.ale.core.validation.QualifiedNames.getQualifiedName;
+
+import java.util.Set;
+
+import org.eclipse.acceleo.query.ast.Expression;
+import org.eclipse.acceleo.query.runtime.IValidationMessage;
+import org.eclipse.acceleo.query.runtime.ValidationMessageLevel;
+import org.eclipse.acceleo.query.runtime.impl.ValidationMessage;
+import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
+import org.eclipse.emf.ecoretools.ale.core.validation.IValidationMessageFactory;
+import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
+import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
+import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
+
+public final class ValidationMessageFactory implements IValidationMessageFactory {
+
+	public static final String BOOLEAN_TYPE = "Expected a boolean expression but was %s";
+	public static final String COLLECTION_TYPE = "Expected Collection but was %s";
+	public static final String EXTENDS_ITSELF = "Reopened %s is extending itself";
+	public static final String ILLEGAL_ASSIGNMENT = "Type mismatch: cannot assign %s to %s";
+	public static final String ILLEGAL_INSERTION = "%s cannot be added to %s (expected %s)";
+	public static final String ILLEGAL_REMOVAL = "%s cannot be removed from %s (expected %s)";
+	public static final String INCOMPATIBLE_TYPE = "Expected %s but was %s";
+	public static final String INCOMPATIBLE_TYPES = "Expected %s but was %s";
+	public static final String INDIRECT_EXTENSION = "Can't extend %s since it is not a direct super type of %s";
+	public static final String UNSUPPORTED_OPERATOR = "%s does not support the '%s' operator";
+	public static final String VOID_RESULT_ASSIGN = "Cannot assign 'result' in a void operation";
+	public static final String UNRESOLVED_TYPE = "Unresolved type %s, it cannot be found in any of the declared packages: %s";
+	
+	private final BaseValidator base;
+	
+	public ValidationMessageFactory(BaseValidator base) {
+		this.base = requireNonNull(base, "base");
+	}
+	
+	@Override
+	public IValidationMessage assignmentToResultInVoidOperation(VariableAssignment assignment) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(VOID_RESULT_ASSIGN,assignment.getName()),
+				base.getStartOffset(assignment),
+				base.getEndOffset(assignment)
+		);
+	}
+	
+	@Override
+	public IValidationMessage expectedBoolean(Expression exp) {
+		Set<IType> actualTypes = base.getPossibleTypes(exp);
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(BOOLEAN_TYPE, commaSeparated(actualTypes)),
+				base.getStartOffset(exp),
+				base.getEndOffset(exp)
+		);
+	}
+	
+	@Override
+	public IValidationMessage extendingItself(ExtendedClass xtdClass) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(EXTENDS_ITSELF, getQualifiedName(xtdClass.getBaseClass())),
+				base.getStartOffset(xtdClass),
+				base.getEndOffset(xtdClass)
+		);
+	}
+	
+	@Override
+	public IValidationMessage forEachCanOnlyIterateOnCollections(ForEach loop) {
+		Set<IType> actualTypes = base.getPossibleTypes(loop.getCollectionExpression());
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(COLLECTION_TYPE, commaSeparated(actualTypes)),
+				base.getStartOffset(loop.getCollectionExpression()),
+				base.getEndOffset(loop.getCollectionExpression())
+		);
+	}
+	
+	@Override
+	public IValidationMessage illegalAssignment(Set<IType> variableTypes, Set<IType> valueTypes, Object assignment) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(ILLEGAL_ASSIGNMENT, commaSeparated(valueTypes), commaSeparated(variableTypes)),
+				base.getStartOffset(assignment),
+				base.getEndOffset(assignment) + 1
+		);
+	}
+	
+	@Override
+	public IValidationMessage illegalInsertion(Set<IType> variableTypes, Set<IType> insertedValueTypes, Set<IType> acceptedValueTypes, Object value) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(ILLEGAL_INSERTION, commaSeparated(insertedValueTypes), commaSeparated(variableTypes), commaSeparated(acceptedValueTypes)),
+				base.getStartOffset(value),
+				base.getEndOffset(value) + 1
+		);
+	}
+	
+	@Override
+	public IValidationMessage illegalRemoval(Set<IType> variableTypes, Set<IType> removedValueTypes, Set<IType> acceptedValueTypes, Object value) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(ILLEGAL_REMOVAL, commaSeparated(removedValueTypes), commaSeparated(variableTypes), commaSeparated(acceptedValueTypes)),
+				base.getStartOffset(value),
+				base.getEndOffset(value) + 1
+		);
+	}
+	
+	@Override
+	public IValidationMessage incompatibleTypes(Attribute att, Set<IType> actualTypes) {
+		EClassifier expectedType = att.getFeatureRef().getEType();
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(INCOMPATIBLE_TYPE, getQualifiedName(expectedType), commaSeparated(actualTypes)),
+				base.getStartOffset(att),
+				base.getEndOffset(att)
+		);
+	}
+	
+	@Override
+	public IValidationMessage incompatibleTypes(Set<IType> expected, Set<IType> actual, Object statement) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(INCOMPATIBLE_TYPES, commaSeparated(expected), commaSeparated(actual)),
+				base.getStartOffset(statement),
+				base.getEndOffset(statement)
+		);
+	}
+	
+	
+	@Override
+	public IValidationMessage indirectExtension(ExtendedClass xtdClass, EClass superBase, EClass baseCls) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(INDIRECT_EXTENSION, getQualifiedName(superBase), getQualifiedName(baseCls)),
+				base.getStartOffset(xtdClass),
+				base.getEndOffset(xtdClass)
+		);
+	}
+
+	@Override
+	public IValidationMessage prohibitedInsertionToSelf(Object statement) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(UNSUPPORTED_OPERATOR, "'self'", "+="),
+				base.getStartOffset(statement),
+				base.getStartOffset(statement) + "self".length()
+		);
+	}
+	
+	@Override
+	public IValidationMessage prohibitedRemovalFromSelf(Object statement) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(UNSUPPORTED_OPERATOR, "'self'", "-="),
+				base.getStartOffset(statement),
+				base.getStartOffset(statement) + "self".length()
+		);
+	}
+	
+	@Override
+	public IValidationMessage unresolvedType(Object expression) {
+		String declaredPackages = base.getQryEnv().getEPackageProvider().getRegisteredEPackages().stream()
+												  .map(EPackage::getName)
+												  .collect(joining(", ","[","]")); 
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				// TODO implement a contextual UnresolvedType to get better name. cf. https://github.com/gemoc/ale-lang/issues/78
+				String.format(UNRESOLVED_TYPE, ""/*getQualifiedName(att.getFeatureRef().getEType())*/, declaredPackages),
+				base.getStartOffset(expression),
+				base.getEndOffset(expression)
+		);
+	}
+	
+	@Override
+	public IValidationMessage unsupportedOperatorOnFeature(Set<IType> currentTypes, Object statement, String featureName, String operator) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(UNSUPPORTED_OPERATOR,commaSeparated(currentTypes), operator),
+				base.getStartOffset(statement),
+				base.getStartOffset(statement) + ("self." + featureName).length()
+		);
+	}
+
+	@Override
+	public IValidationMessage unsupportedOperatorOnVariable(Set<IType> currentTypes, Object statement, String variableName, String operator) {
+		return new ValidationMessage(
+				ValidationMessageLevel.ERROR,
+				String.format(UNSUPPORTED_OPERATOR,commaSeparated(currentTypes), operator),
+				base.getStartOffset(statement),
+				base.getStartOffset(statement) + variableName.length()
+		);
+	}
+	
+	private static String commaSeparated(Set<IType> types) {
+		return types.stream()
+					.map(type -> getQualifiedName(type))
+					.sorted()
+					.collect(joining(",","[","]"));
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignResult.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignResult.implem
@@ -3,4 +3,12 @@ open class EClass {
 	def String op2(){
 		result := 'foobar';
 	}
+	
+	def Boolean op3() {
+		result := false;
+	}
+	
+	def Integer op4() {
+		result := 42;
+	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertIntToInt.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertIntToInt.implem
@@ -1,0 +1,7 @@
+behavior test.declself;
+open class EClass {
+	Integer i;
+	def void foo() {
+		self.i += 42;
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertIntToString.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertIntToString.implem
@@ -1,0 +1,7 @@
+behavior test.declself;
+open class EClass {
+	String str;
+	def void foo() {
+		self.str += 42;
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertIntoLocalBooleanError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertIntoLocalBooleanError.implem
@@ -1,0 +1,7 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Boolean supportsOperator := false;
+		supportsOperator += true;
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollection.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollection.implem
@@ -1,0 +1,11 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(String) fourFive := Sequence{'four', 'five'};
+		
+		Sequence(String) numbers := Sequence{'one', 'two'};
+		numbers += 'three';
+		numbers += fourFive;
+		numbers += Sequence{'six', 'seven'};
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollectionError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollectionError.implem
@@ -1,0 +1,11 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(Integer) fourFive := Sequence{4, 5};
+		
+		Sequence(String) numbers := Sequence{'one', 'two'};
+		numbers += 3;
+		numbers += fourFive;
+		numbers += Sequence{6, 7};
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollectionInForEachLoop.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollectionInForEachLoop.implem
@@ -1,0 +1,14 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(String) numbers := Sequence{'one', 'two', 'three'};
+		Sequence(String) strings := Sequence{};
+		
+		for (number in numbers) {
+			Sequence(String) strings2 := Sequence{};
+			
+			strings += number;
+			strings2 += number;
+		}
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollectionInForEachLoopError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertLocalCollectionInForEachLoopError.implem
@@ -1,0 +1,14 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(Integer) numbers := Sequence{1, 2, 3};
+		Sequence(String) strings := Sequence{};
+		
+		for (number in numbers) {
+			Sequence(String) strings2 := Sequence{};
+			
+			strings += number;
+			strings2 += number;
+		}
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertResult.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertResult.implem
@@ -1,0 +1,16 @@
+behavior test.featins;
+open class EClass {
+	def String name(){
+		result += 'Smith';
+	}
+	
+	def Integer age() {
+		result += 18;
+	}
+	
+	def Sequence(Integer) numbers() {
+		result += 42;
+		result += Sequence{56, 84};
+	}
+	
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertResultError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertResultError.implem
@@ -1,0 +1,16 @@
+behavior test.featins;
+open class EClass {
+	def String name(){
+		result += 18;
+	}
+	
+	def Boolean isAdult() {
+		result += true;
+	}
+	
+	def Sequence(Integer) numbers() {
+		result += 'string';
+		result += Sequence{true, false};
+	}
+	
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertSelf.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertSelf.implem
@@ -1,0 +1,6 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		self += 'this is prohibited';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertStringToInt.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertStringToInt.implem
@@ -1,0 +1,7 @@
+behavior test.declself;
+open class EClass {
+	Integer i;
+	def void foo() {
+		self.i += 'hello';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertStringToString.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/insertStringToString.implem
@@ -1,0 +1,7 @@
+behavior test.declself;
+open class EClass {
+	String str;
+	def void foo() {
+		self.str += 'hello';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollection.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollection.implem
@@ -1,0 +1,11 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(String) fourFive := Sequence{'four', 'five'};
+		
+		Sequence(String) numbers := Sequence{'one', 'two'};
+		numbers -= 'three';
+		numbers -= fourFive;
+		numbers -= Sequence{'six', 'seven'};
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollectionError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollectionError.implem
@@ -1,0 +1,11 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(Integer) fourFive := Sequence{4, 5};
+		
+		Sequence(String) numbers := Sequence{'one', 'two'};
+		numbers -= 3;
+		numbers -= fourFive;
+		numbers -= Sequence{6, 7};
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollectionInForEachLoop.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollectionInForEachLoop.implem
@@ -1,0 +1,14 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(String) numbers := Sequence{'one', 'two', 'three'};
+		Sequence(String) strings := Sequence{};
+		
+		for (number in numbers) {
+			Sequence(String) strings2 := Sequence{};
+			
+			strings -= number;
+			strings2 -= number;
+		}
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollectionInForEachLoopError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalCollectionInForEachLoopError.implem
@@ -1,0 +1,14 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Sequence(Integer) numbers := Sequence{1, 2, 3};
+		Sequence(String) strings := Sequence{};
+		
+		for (number in numbers) {
+			Sequence(String) strings2 := Sequence{};
+			
+			strings -= number;
+			strings2 -= number;
+		}
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalVariablesError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeLocalVariablesError.implem
@@ -1,0 +1,10 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		Boolean supportsOperator := false;
+		supportsOperator -= true;
+		
+		String string := 'string';
+		string -= 'str';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeResult.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeResult.implem
@@ -1,0 +1,12 @@
+behavior test.featins;
+open class EClass {
+	def Integer age() {
+		result -= 18;
+	}
+	
+	def Sequence(Integer) numbers() {
+		result -= 42;
+		result -= Sequence{56, 84};
+	}
+	
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeResultError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeResultError.implem
@@ -1,0 +1,16 @@
+behavior test.featins;
+open class EClass {
+	def Integer age(){
+		result -= '18';
+	}
+	
+	def Boolean isAdult() {
+		result -= true;
+	}
+	
+	def Sequence(Integer) numbers() {
+		result -= 'string';
+		result -= Sequence{true, false};
+	}
+	
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeSelf.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/removeSelf.implem
@@ -1,0 +1,6 @@
+behavior test.featins;
+open class EClass {
+	def void op(){
+		self -= 'this is prohibited';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/BaseValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/BaseValidatorTest.java
@@ -70,7 +70,7 @@ public class BaseValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 67, 92, "Expected [ecore::EBoolean] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 77, 92, "Type mismatch: cannot assign [java.lang.String] to [ecore::EBoolean]", msg.get(0));
 	}
 
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
@@ -900,6 +900,23 @@ public class NameValidatorTest {
 		
 		assertEquals(2, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 112, 117, "Feature wrong not found in EClass EClass", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 118, "Expected [ecore::EInt] but was [Nothing(Feature wrong not found in EClass EClass)]", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 108, 118, "Type mismatch: cannot assign [Nothing(Feature wrong not found in EClass EClass)] to [ecore::EInt]", msg.get(1));
+	}
+	
+	/*
+	 * Test value of result conflict the return type void
+	 */
+	@Test
+	public void testReturnAssignVoid() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/assignVoid.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 65, 76, "Cannot assign 'result' in a void operation", msg.get(0));
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -219,7 +219,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 73, 90, "Expected ecore::EString but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 73, 90, "Expected [ecore::EString] but was [java.lang.Integer]", msg.get(0));
 	}
 	
 	/*
@@ -252,7 +252,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 78, 95, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 87, 95, "Type mismatch: cannot assign [java.lang.String] to [ecore::EInt]", msg.get(0));
 	}
 	
 	/*
@@ -285,7 +285,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 92, 109, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 104, 109, "Type mismatch: cannot assign [java.lang.String] to [ecore::EInt]", msg.get(0));
 	}
 	
 	/*
@@ -318,7 +318,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 66, 77, "Expected [ecore::EString] but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 76, 77, "Type mismatch: cannot assign [java.lang.Integer] to [ecore::EString]", msg.get(0));
 	}
 	
 	/*
@@ -335,7 +335,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 65, 76, "'result' is assigned in void operation", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 65, 76, "Cannot assign 'result' in a void operation", msg.get(0));
 	}
 	
 	/*
@@ -368,7 +368,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 64, 83, "Expected [ecore::EPackage] but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 81, 83, "Type mismatch: cannot assign [java.lang.Integer] to [ecore::EPackage]", msg.get(0));
 	}
 	
 	/*
@@ -401,7 +401,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 82, 101, "Expected [ecore::EString] but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 99, 101, "Type mismatch: cannot assign [java.lang.Integer] to [ecore::EString]", msg.get(0));
 	}
 	
 	/*
@@ -434,7 +434,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 83, 106, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 101, 106, "Type mismatch: cannot assign [java.lang.String] to [ecore::EInt]", msg.get(0));
 	}
 	
 	/*
@@ -466,9 +466,8 @@ public class TypeValidatorTest {
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
-		assertEquals(2, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 61, 64, "Expected Collection but was [ecore::EBoolean]", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 61, 82, "Expected [ecore::EBoolean] but was [ecore::EClass]", msg.get(1));
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 61, 74, "[ecore::EBoolean] does not support the '+=' operator", msg.get(0));
 	}
 	
 	/*
@@ -501,7 +500,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 79, 82, "Expected Collection but was [ecore::EClass]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 79, 90, "[ecore::EClass] does not support the '+=' operator", msg.get(0));
 	}
 	
 	/*
@@ -534,7 +533,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 82, 85, "Expected Collection but was [ecore::EClass]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 82, 93, "[ecore::EClass] does not support the '+=' operator", msg.get(0));
 	}
 	
 	/*
@@ -567,7 +566,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 61, 89, "Expected [ecore::EClass] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 81, 89, "[java.lang.String] cannot be added to [Collection(ecore::EClass)] (expected [Collection(ecore::EClass),ecore::EClass])", msg.get(0));
 	}
 	
 	/*
@@ -600,7 +599,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 85, 108, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 103, 108, "[java.lang.String] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
 	}
 	
 	/*
@@ -633,7 +632,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 88, 111, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 106, 111, "[java.lang.String] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
 	}
 	
 	/*
@@ -665,9 +664,8 @@ public class TypeValidatorTest {
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
-		assertEquals(2, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 60, 63, "Expected Collection but was [ecore::EBoolean]", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 60, 81, "Expected [ecore::EBoolean] but was [ecore::EClass]", msg.get(1));
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 60, 73, "[ecore::EBoolean] does not support the '-=' operator", msg.get(0));
 	}
 	
 	/*
@@ -700,7 +698,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 78, 81, "Expected Collection but was [ecore::EClass]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 78, 89, "[ecore::EClass] does not support the '-=' operator", msg.get(0));
 	}
 	
 	/*
@@ -732,9 +730,8 @@ public class TypeValidatorTest {
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
-		assertEquals(2, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 81, 84, "Expected Collection but was [ecore::EClass]", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 81, 100, "Expected [ecore::EClass] but was [test::featrm::MyRuntimeClass]", msg.get(1));
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 81, 92, "[ecore::EClass] does not support the '-=' operator", msg.get(0));
 	}
 	
 	/*
@@ -767,7 +764,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 60, 88, "Expected [ecore::EClass] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 80, 88, "[java.lang.String] cannot be removed from [Collection(ecore::EClass)] (expected [Collection(ecore::EClass),ecore::EClass])", msg.get(0));
 	}
 	
 	/*
@@ -800,7 +797,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 85, 108, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 103, 108, "[java.lang.String] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
 	}
 	
 	/*
@@ -827,13 +824,325 @@ public class TypeValidatorTest {
 		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeAttribRuntimeClassError.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 106, 111, "[java.lang.String] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
+	}
+	
+	/**
+	 * Test using the '+=' on self raise an error
+	 */
+	@Test
+	public void testInsertSelf() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertSelf.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		
 		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 88, 111, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 61, 65, "'self' does not support the '+=' operator", msg.get(0));
+	}
+	
+	/**
+	 * Test that a value can be inserted into a local Collection
+	 */
+	@Test
+	public void testInsertIntoLocalCollection() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertLocalCollection.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Test that a value cannot be inserted into a local Collection if their types mismatch
+	 */
+	@Test
+	public void testInsertIntoLocalCollectionError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertLocalCollectionError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(3, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 177, 178, "[java.lang.Integer] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 193, 201, "[Collection(java.lang.Integer)] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 216, 230, "[Collection(java.lang.Integer)] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(2));
+	}
+	
+	/**
+	 * Test that the iterator of a for-each loop can be inserted into a local collection
+	 */
+	@Test
+	public void testInsertIntoLocalCollectionInForEachLoop() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertLocalCollectionInForEachLoop.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Test that the iterator of a for-each loop cannot be inserted into a local collection if their types mismatch
+	 */
+	@Test
+	public void testInsertIntoLocalCollectionInForEachLoopError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertLocalCollectionInForEachLoopError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(2, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 244, 250, "[java.lang.Integer] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 267, 273, "[java.lang.Integer] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
+	}
+	
+	/**
+	 * Test that some do not support the '-=' operator
+	 */
+	@Test
+	public void testInsertIntoLocalVariableError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertIntoLocalBooleanError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 98, 114, "[ecore::EBoolean] does not support the '+=' operator", msg.get(0));
+	}
+	
+	/**
+	 * Test that the result special variable supports the '+=' operator
+	 */
+	@Test
+	public void testInsertResult() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertResult.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Test that using '+=' with the result special variable produces an error when types mismatch
+	 */
+	@Test
+	public void testInsertResultError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertResultError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(4, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 75, 77, "[java.lang.Integer] cannot be added to [ecore::EString] (expected [ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 111, 117, "[ecore::EBoolean] does not support the '+=' operator", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 179, 187, "[java.lang.String] cannot be added to [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 201, 222, "[Collection(java.lang.Boolean)] cannot be added to [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(3));
+	}
+	
+	/**
+	 * Test that the result special variable supports the '-=' operator
+	 */
+	@Test
+	public void testRemoveResult() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeResult.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Test that using '-=' with the result special variable produces an error when types mismatch
+	 */
+	@Test
+	public void testRemoveResultError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeResultError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(4, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 75, 79, "[java.lang.String] cannot be removed from [ecore::EInt] (expected [ecore::EInt])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 113, 119, "[ecore::EBoolean] does not support the '-=' operator", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 181, 189, "[java.lang.String] cannot be removed from [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 203, 224, "[Collection(java.lang.Boolean)] cannot be removed from [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(3));
+	}
+	
+	@Test
+	public void testInsertStringToString() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertStringToString.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	@Test
+	public void testInsertIntToString() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertIntToString.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 89, 91, "[java.lang.Integer] cannot be added to [ecore::EString] (expected [ecore::EString])", msg.get(0));
+	}
+	
+	@Test
+	public void testInsertStringToInt() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertStringToInt.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 86, 93, "[java.lang.String] cannot be added to [ecore::EInt] (expected [ecore::EInt])", msg.get(0));
+	}
+	
+	@Test
+	public void testInsertIntToInt() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/insertIntToInt.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Test using the '-=' on self raise an error
+	 */
+	@Test
+	public void testRemoveFromSelf() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeSelf.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 61, 65, "'self' does not support the '-=' operator", msg.get(0));
+	}
+	
+	/**
+	 * Test that a value can be removed from a local Collection
+	 */
+	@Test
+	public void testRemoveFromLocalCollection() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeLocalCollection.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Test that a value cannot be removed from a local Collection if their types mismatch
+	 */
+	@Test
+	public void testRemoveFromLocalCollectionError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeLocalCollectionError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(3, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 177, 178, "[java.lang.Integer] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 193, 201, "[Collection(java.lang.Integer)] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 216, 230, "[Collection(java.lang.Integer)] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(2));
+	}
+	
+	/**
+	 * Test that the iterator of a for-each loop can be removed from a local collection
+	 */
+	@Test
+	public void testRemoveFromLocalCollectionInForEachLoop() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeLocalCollectionInForEachLoop.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(0, msg.size());
+	}
+	
+	/**
+	 * Test that the iterator of a for-each loop cannot be removed from a local collection if their types mismatch
+	 */
+	@Test
+	public void testRemoveFromLocalCollectionInForEachLoopError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeLocalCollectionInForEachLoopError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(2, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 244, 250, "[java.lang.Integer] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 267, 273, "[java.lang.Integer] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
+	}
+	
+	/**
+	 * Test that some types do not support the '-=' operator
+	 */
+	@Test
+	public void testRemoveFromLocalVariableError() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/removeLocalVariablesError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(2, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 98, 114, "[ecore::EBoolean] does not support the '-=' operator", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 158, 164, "[ecore::EString] does not support the '-=' operator", msg.get(1));
 	}
 	
 	/*
@@ -899,7 +1208,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 134, 144, "Expected ecore::EInt but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 134, 144, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
 	}
 	
 	/*
@@ -932,7 +1241,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 63, 69, "Expected ecore::EBoolean but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 63, 69, "Expected a boolean expression but was [java.lang.Integer]", msg.get(0));
 	}
 	
 	/*
@@ -965,7 +1274,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 69, 78, "Expected ecore::EBoolean but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 69, 78, "Expected a boolean expression but was [java.lang.String]", msg.get(0));
 	}
 	
 	/*
@@ -1191,7 +1500,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 66, 106, "Expected ecore::EClass but was [ecore::EOperation]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 66, 106, "Expected [ecore::EClass] but was [ecore::EOperation]", msg.get(0));
 	}
 	
 	@Test
@@ -1231,7 +1540,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 70, 94, "Expected [Collection(ecore::EClass)] but was [ecore::EClass]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 94, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
 	}
 	
 	@Test
@@ -1245,7 +1554,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 70, 91, "Expected [Collection(ecore::EClass)] but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 91, "Type mismatch: cannot assign [java.lang.Integer] to [Collection(ecore::EClass)]", msg.get(0));
 	}
 	
 	@Test
@@ -1284,7 +1593,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 71, 101, "Expected Collection(ecore::EInt) but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 71, 101, "Expected [Collection(ecore::EInt)] but was [java.lang.Integer]", msg.get(0));
 	}
 	
 	@Test
@@ -1311,7 +1620,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 118, 143, "Expected [Collection(ecore::EInt)] but was [Sequence(java.lang.String)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 125, 143, "Type mismatch: cannot assign [Collection(java.lang.String)] to [Collection(ecore::EInt)]", msg.get(0));
 	}
 	@Test
 	public void testAssignSequenceFeature() {
@@ -1336,8 +1645,8 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(2, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 124, 147, "Expected [ecore::EEList] but was [ecore::EClass]", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 151, 192, "Expected [ecore::EEList] but was [ecore::EClass]", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 143, 147, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 170, 192, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(1));
 	}
 	@Test
 	public void testAssignSequenceVarDecl() {
@@ -1362,10 +1671,10 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(4, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 85, 128, "Expected Collection(ecore::EClass) but was [ecore::EClass]", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 132, 151, "Expected [Collection(ecore::EClass)] but was [ecore::EClass]", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 155, 216, "Expected Collection(ecore::EClass) but was [ecore::EClass]", msg.get(2));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 220, 257, "Expected [Collection(ecore::EClass)] but was [ecore::EClass]", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 85, 128, "Expected [Collection(ecore::EClass)] but was [ecore::EClass]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 147, 151, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 155, 216, "Expected [Collection(ecore::EClass)] but was [ecore::EClass]", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 235, 257, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(3));
 	}
 	
 	@Test
@@ -1391,7 +1700,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 100, 132, "Expected [Collection(?)] but was [ecore::EClass]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 110, 132, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
 	}
 	
 


### PR DESCRIPTION
Remove duplicated code in ALE's type checker to make the code easier to maintain.

## Changes

 - introduce a new `TypeChecker` class responsible of checking compatibility between types
 - refactor some methods of `TypeValidator` to remove duplicated code
 - some error messages have new text and position to make them closer to what is usually done (e.g. by JDT); see changes in `TypeValidatorTest`

## New features

 - check type of variables when using the `+=` and `-=` operators (until now [a warning was shown](https://github.com/gemoc/ale-lang/pull/69))
 - check the type of variables declared within _for each_ loops
 - properly retrieve generic type parameters for methods return type (and thus for the `result` variable) and attribute declaration
 - check types when assigning a value to `result` (`:=`, `+=` and `-=` operators)