### PR TITLE
add autoclosable api to ALEInterpreter

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/META-INF/MANIFEST.MF
@@ -23,3 +23,5 @@ Require-Bundle: org.eclipse.emf.ecoretools.ale.ide,
  org.eclipse.emf.ecoretools.ale.xtext,
  org.eclipse.emf.ecoretools.design
 Bundle-Vendor: Inria/Obeo
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.emf.ecoretools.ale.ide.ui

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/Activator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/Activator.java
@@ -13,6 +13,7 @@ package org.eclipse.emf.ecoretools.ale.ide.ui;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.core.runtime.Status;
 import org.eclipse.sirius.business.api.componentization.ViewpointRegistry;
 import org.eclipse.sirius.viewpoint.description.Viewpoint;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -22,55 +23,65 @@ import org.osgi.framework.BundleContext;
  * The activator class controls the plug-in life cycle
  */
 public class Activator extends AbstractUIPlugin {
-    // The plug-in ID
-    public static final String PLUGIN_ID = "org.eclipse.emf.ecoretools.ale.ide.ui";
+	// The plug-in ID
+	public static final String PLUGIN_ID = "org.eclipse.emf.ecoretools.ale.ide.ui";
 
-    // The shared instance
-    private static Activator plugin;
+	// The shared instance
+	private static Activator plugin;
 
-    private static Set<Viewpoint> viewpoints; 
+	private static Set<Viewpoint> viewpoints;
 
-    /**
-     * The constructor
-     */
-    public Activator() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
-     */
-    public void start(BundleContext context) throws Exception {
-      super.start(context);
-	  plugin = this;
-	  viewpoints = new HashSet<Viewpoint>();
-	  viewpoints.addAll(ViewpointRegistry.getInstance().registerFromPlugin(PLUGIN_ID + "/description/ale.odesign")); 
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
-     */
-    public void stop(BundleContext context) throws Exception {
-	plugin = null;
-	if (viewpoints != null) {
-	    for (final Viewpoint viewpoint: viewpoints) {
-		ViewpointRegistry.getInstance().disposeFromPlugin(viewpoint);
-	    }
-	    viewpoints.clear();
-	    viewpoints = null; 
+	/**
+	 * The constructor
+	 */
+	public Activator() {
 	}
-	super.stop(context);
-    }
 
-    /**
-     * Returns the shared instance
-     * 
-     * @return the shared instance
-     */
-    public static Activator getDefault() {
-	return plugin;
-    }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.
+	 * BundleContext)
+	 */
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+		viewpoints = new HashSet<Viewpoint>();
+		viewpoints.addAll(ViewpointRegistry.getInstance().registerFromPlugin(PLUGIN_ID + "/description/ale.odesign"));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	 */
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		if (viewpoints != null) {
+			for (final Viewpoint viewpoint : viewpoints) {
+				ViewpointRegistry.getInstance().disposeFromPlugin(viewpoint);
+			}
+			viewpoints.clear();
+			viewpoints = null;
+		}
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 * 
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
+
+	public static void warn(String msg, Throwable e) {
+		Activator.getDefault().getLog().log(new Status(Status.WARNING, PLUGIN_ID, Status.OK, msg, e));
+	}
+
+	public static void error(String msg, Throwable e) {
+		Activator.getDefault().getLog().log(new Status(Status.ERROR, PLUGIN_ID, Status.OK, msg, e));
+	}
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/RunModelAction.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/RunModelAction.java
@@ -11,6 +11,7 @@
 package org.eclipse.emf.ecoretools.ale.ide.ui.launchconfig;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +28,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.ecoretools.ale.ALEInterpreter;
+import org.eclipse.emf.ecoretools.ale.ALEInterpreter.ClosedALEInterpreterException;
 import org.eclipse.emf.ecoretools.ale.ide.WorkbenchDsl;
 import org.eclipse.emf.ecoretools.ale.ide.ui.Activator;
 import org.eclipse.sirius.common.tools.api.interpreter.IInterpreterWithDiagnostic.IEvaluationResult;
@@ -43,36 +45,38 @@ public class RunModelAction {
 	 * Open a selection dialog to get the model file before launch
 	 */
 	public static void launch(Shell shell, IResource dslFile) {
-		
+
 		/*
 		 * Selected model
 		 */
-		FilteredResourcesSelectionDialog dialog = new FilteredResourcesSelectionDialog(shell, false, ResourcesPlugin.getWorkspace().getRoot(), IResource.FILE);
+		FilteredResourcesSelectionDialog dialog = new FilteredResourcesSelectionDialog(shell, false,
+				ResourcesPlugin.getWorkspace().getRoot(), IResource.FILE);
 		dialog.setTitle("Resource Selection");
 		dialog.setInitialPattern("*.xmi");
-		
+
 		// If possible, select by default a .xmi file next to the .dsl file
-		// NOTE: actually, does not work at the moment, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=214491
+		// NOTE: actually, does not work at the moment, see
+		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=214491
 		Optional<IResource> siblingXmi = findSiblingXmi(dslFile);
 		siblingXmi.ifPresent(dialog::setInitialSelections);
-		
+
 		dialog.open();
 		Object[] selected = dialog.getResult();
-		
-		if(selected != null && selected.length == 1 && selected[0] instanceof IResource) {
-			launch(dslFile,(IResource)selected[0]);
+
+		if (selected != null && selected.length == 1 && selected[0] instanceof IResource) {
+			launch(dslFile, (IResource) selected[0]);
 		}
 	}
-	
+
 	/**
 	 * Execute a DSL on a model
 	 */
 	public static void launch(IResource dslFile, IResource modelFile) {
-		
+
 		String dslProject = dslFile.getProject().getName();
 		String modelLocation = modelFile.getLocationURI().toString();
 		String modelProject = modelFile.getProject().getName();
-		
+
 		/*
 		 * Init interpreter
 		 * 
@@ -82,63 +86,65 @@ public class RunModelAction {
 		Set<String> plugins = new HashSet<>();
 		projects.add(dslProject);
 		projects.add(modelProject);
-		ALEInterpreter interpreter = new ALEInterpreter();
-		interpreter.javaExtensions.updateScope(plugins,projects);
-		interpreter.javaExtensions.reloadIfNeeded();
-		
+
 		/*
 		 * Eval
 		 */
 		Job evalJob = new Job("AQL Eval") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				
+
 				MessageConsole console = findConsole("ALE Console");
 				PrintStream oldOut = System.out;
 				try {
 					System.setOut(new PrintStream(console.newMessageStream()));
-					
-					System.out.println("\nRun "+dslFile.getName());
+
+					System.out.println("\nRun " + dslFile.getName());
 					System.out.println("------------");
-					
-					Thread execThread = new Thread("Aql eval thread"){
+
+					Thread execThread = new Thread("Aql eval thread") {
 						@Override
 						public void run() {
-							try {
-								IEvaluationResult result = interpreter.eval(modelLocation, new ArrayList<>(), new WorkbenchDsl(dslFile.getLocationURI().getPath()));
+							try (ALEInterpreter interpreter = new ALEInterpreter()) {
+								interpreter.javaExtensions.updateScope(plugins, projects);
+								interpreter.javaExtensions.reloadIfNeeded();
+								IEvaluationResult result = interpreter.eval(modelLocation, new ArrayList<>(),
+										new WorkbenchDsl(dslFile.getLocationURI().getPath()));
 								interpreter.getLogger().diagnosticForHuman();
-								
-								if(result.getDiagnostic().getMessage() != null) {
+
+								if (result.getDiagnostic().getMessage() != null) {
 									System.out.println(result.getDiagnostic().getMessage());
 								}
-							} catch (FileNotFoundException e) {
+							} catch (ClosedALEInterpreterException | IOException e) {
 								e.printStackTrace();
+								Activator.error(e.getMessage(), e);
 							}
 							this.stop();
 						}
 					};
 					execThread.start();
-					
-					while(execThread.isAlive()){
-						if(monitor.isCanceled()){
+
+					while (execThread.isAlive()) {
+						if (monitor.isCanceled()) {
 							execThread.stop();
 							return Status.CANCEL_STATUS;
 						}
-						 try {
+						try {
 							Thread.sleep(1000);
 						} catch (InterruptedException e) {
 							Thread.currentThread().interrupt();
-							
+
 							// Main thread has been interrupted: let's stop the evaluation and move on
 							execThread.stop();
-							return new Status(IStatus.CANCEL, Activator.PLUGIN_ID, "Execution thread has been interrupted", e);
+							return new Status(IStatus.CANCEL, Activator.PLUGIN_ID,
+									"Execution thread has been interrupted", e);
 						}
 					}
-					
-					if(execThread.isAlive()){
+
+					if (execThread.isAlive()) {
 						execThread.stop();
 					}
-					
+
 				} finally {
 					// Ensure output stream is always reset
 					System.setOut(oldOut);
@@ -148,7 +154,7 @@ public class RunModelAction {
 		};
 		evalJob.schedule();
 	}
-	
+
 	private static MessageConsole findConsole(String name) {
 		ConsolePlugin plugin = ConsolePlugin.getDefault();
 		IConsoleManager conMan = plugin.getConsoleManager();
@@ -161,19 +167,18 @@ public class RunModelAction {
 		conMan.addConsoles(new IConsole[] { myConsole });
 		return myConsole;
 	}
-	
+
 	/** Find a .xmi file located next to the given resource. */
 	private static Optional<IResource> findSiblingXmi(IResource dslFile) {
 		Stream<IResource> siblings;
 		try {
 			siblings = Arrays.stream(dslFile.getParent().members());
-			
+
 		} catch (CoreException | NullPointerException e) {
 			// For some reason we cannot check .dsl file's siblings.
 			// Never mind, we don't want to bother the user with that.
 			return Optional.empty();
 		}
-		return siblings.filter(sibling -> "xmi".equalsIgnoreCase(sibling.getFileExtension()))
-					   .findAny();
+		return siblings.filter(sibling -> "xmi".equalsIgnoreCase(sibling.getFileExtension())).findAny();
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/META-INF/MANIFEST.MF
@@ -14,3 +14,5 @@ Export-Package: org.eclipse.emf.ecoretools.ale.core.interpreter.test,
  org.eclipse.emf.ecoretools.ale.core.parser.test,
  org.eclipse.emf.ecoretools.ale.core.validation.test,
  org.eclipse.emf.ecoretools.ale.test
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.emf.ecoretools.ale.tests

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
@@ -17,998 +17,1131 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.acceleo.query.runtime.IService;
 import org.eclipse.acceleo.query.runtime.ServiceUtils;
 import org.eclipse.emf.common.util.Diagnostic;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecoretools.ale.ALEInterpreter;
+import org.eclipse.emf.ecoretools.ale.ALEInterpreter.ClosedALEInterpreterException;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.services.ServiceCallListener;
 import org.eclipse.emf.ecoretools.ale.core.parser.Dsl;
 import org.eclipse.emf.ecoretools.ale.core.parser.DslBuilder;
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult;
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.sirius.common.tools.api.interpreter.IInterpreterWithDiagnostic.IEvaluationResult;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 /**
  * This class test the execution of ModelBehavior
  */
 public class EvalTest {
-	
+
 	ALEInterpreter interpreter;
-	
+
 	@Before
 	public void setup() {
 		interpreter = new ALEInterpreter();
 	}
-	
+
+	@After
+	public void release() throws IOException {
+		if (interpreter != null) {
+			interpreter.close();
+		}
+	}
+
 	@Test
-	public void testAccessLocalVariable(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/localvar.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessLocalVariable() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/localvar.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("foobar",res.getValue());
+
+		assertEquals("foobar", res.getValue());
 	}
-	
+
 	@Test
-	public void testAccessParameter(){
+	public void testAccessParameter() throws ClosedALEInterpreterException {
 		String obj = "";
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/args.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/args.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(obj), parsedSemantics);
-		
-		assertEquals(obj,res.getValue());
-	}
-	
-	@Test
-	public void testAccessSelf(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/self.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(caller,res.getValue());
-	}
-	
-	@Test
-	public void testAccessSelfDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/selfDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("foo",res.getValue());
-	}
-	
-	@Test
-	public void testAccessCreateDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/createDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("foo",res.getValue());
-	}
-	
-	@Test
-	public void testAccessLocalDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/localDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("foo",res.getValue());
+
+		assertEquals(obj, res.getValue());
 	}
 
 	@Test
-	public void testAccessParamDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/paramDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessSelf() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/self.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(caller, res.getValue());
+	}
+
+	@Test
+	public void testAccessSelfDynamicAttribute() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/selfDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals("foo", res.getValue());
+	}
+
+	@Test
+	public void testAccessCreateDynamicAttribute() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/createDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals("foo", res.getValue());
+	}
+
+	@Test
+	public void testAccessLocalDynamicAttribute() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/localDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals("foo", res.getValue());
+	}
+
+	@Test
+	public void testAccessParamDynamicAttribute() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/paramDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EObject newInstance = EcoreUtil.create(caller.eClass());
-		IEvaluationResult res = interpreter.eval(caller,  Arrays.asList(newInstance), parsedSemantics);
-		
-		assertEquals("foo",res.getValue());
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(newInstance), parsedSemantics);
+
+		assertEquals("foo", res.getValue());
 	}
 
 	@Test
-	public void testAccessResultDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/resultDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessResultDynamicAttribute() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/resultDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("foo",res.getValue());
+
+		assertEquals("foo", res.getValue());
 	}
-	
+
 	@Test
-	public void testAccessCallDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/callDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessCallDynamicAttribute() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/callDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("foo",res.getValue());
+
+		assertEquals("foo", res.getValue());
 	}
-	
+
 	@Test
-	public void testNullDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/nullDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testNullDynamicAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/nullDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(Diagnostic.OK, res.getDiagnostic().getSeverity());		
-		assertEquals(null,res.getValue());
+
+		assertEquals(Diagnostic.OK, res.getDiagnostic().getSeverity());
+		assertEquals(null, res.getValue());
 	}
-	
+
 	@Test
-	public void testUnknownDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/unknownDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testUnknownDynamicAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/unknownDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(Diagnostic.WARNING, res.getDiagnostic().getSeverity());		
+
+		assertEquals(Diagnostic.WARNING, res.getDiagnostic().getSeverity());
 		assertEquals("An error occured during evaluation of a query", res.getDiagnostic().getMessage());
-		assertEquals(null,res.getValue());
+		assertEquals(null, res.getValue());
 	}
-	
+
 	@Test
-	public void testAccessSelfAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/selfAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessSelfAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/selfAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EStructuralFeature field = caller.eClass().getEStructuralFeature("field");
 		caller.eSet(field, 1);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(1,res.getValue());
+
+		assertEquals(1, res.getValue());
 	}
-	
+
 	@Test
-	public void testAccessLocalAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/localAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessLocalAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/localAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EStructuralFeature field = caller.eClass().getEStructuralFeature("field");
 		caller.eSet(field, 2);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
+
+		assertEquals(2, res.getValue());
 	}
 
 	@Test
-	public void testAccessParamAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/paramAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessParamAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/paramAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EObject newInstance = EcoreUtil.create(caller.eClass());
 		EStructuralFeature field = newInstance.eClass().getEStructuralFeature("field");
 		newInstance.eSet(field, 3);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(newInstance), parsedSemantics);
-		
-		assertEquals(3,res.getValue());
+
+		assertEquals(3, res.getValue());
 	}
 
 	@Test
-	public void testAccessResultAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/resultAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessResultAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/resultAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EStructuralFeature field = caller.eClass().getEStructuralFeature("field");
 		caller.eSet(field, 4);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(4,res.getValue());
+
+		assertEquals(4, res.getValue());
 	}
-	
+
 	@Test
-	public void testAccessCallAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/callAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAccessCallAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/callAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EStructuralFeature field = caller.eClass().getEStructuralFeature("field");
 		caller.eSet(field, 5);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(5,res.getValue());
-	}
-	
-	@Test
-	public void testAssignSelfDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/selfDynamicAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("bar",res.getValue());
-	}
-	
-	@Test
-	public void testAssignLocalDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/localDynamicAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("bar",res.getValue());
-	}
-	
-	@Test
-	public void testAssignParamDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/paramDynamicAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		EObject newInstance = EcoreUtil.create(caller.eClass());
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(newInstance), parsedSemantics);
-		
-		assertEquals("bar",res.getValue());
-	}
-	
-	@Test
-	public void testAssignResultDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/resultDynamicAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("bar",res.getValue());
-	}
-	
-	@Test
-	public void testAssignCallDynamicAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/callDynamicAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("bar",res.getValue());
-	}
-	
-	@Test
-	public void testAssignSelfAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/selfAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(1,res.getValue());
-	}
-	
-	@Test
-	public void testAssignLocalAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/localAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
-	}
-	
-	@Test
-	public void testAssignParamAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/paramAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		EObject newInstance = EcoreUtil.create(caller.eClass());
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(newInstance), parsedSemantics);
-		
-		assertEquals(3,res.getValue());
+
+		assertEquals(5, res.getValue());
 	}
 
 	@Test
-	public void testAssignResultAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/resultAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignSelfDynamicAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/selfDynamicAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(4,res.getValue());
+
+		assertEquals("bar", res.getValue());
 	}
 
 	@Test
-	public void testAssignCallAttribute(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/callAttributeAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignLocalDynamicAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/localDynamicAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(5,res.getValue());
+
+		assertEquals("bar", res.getValue());
 	}
-	
+
 	@Test
-	public void testSelfCall(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/selfCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(1,res.getValue());
-	}
-	
-	@Test
-	public void testLocalCall(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/localCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
-	}
-	
-	@Test
-	public void testAttributeCall(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/attributeCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(3,res.getValue());
-	}
-	
-	@Test
-	public void testDynamicAttributeCall(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/dynamicAttributeCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(4,res.getValue());
-	}
-	
-	@Test
-	public void testParamCall(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/paramCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignParamDynamicAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/paramDynamicAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EObject newInstance = EcoreUtil.create(caller.eClass());
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(newInstance), parsedSemantics);
-		
-		assertEquals(5,res.getValue());
+
+		assertEquals("bar", res.getValue());
 	}
-	
+
 	@Test
-	public void testParamValue(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/paramValue.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignResultDynamicAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/resultDynamicAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(6,res.getValue());
+
+		assertEquals("bar", res.getValue());
 	}
-	
+
 	@Test
-	public void testResultCall(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/resultCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignCallDynamicAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/callDynamicAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(6,res.getValue());
+
+		assertEquals("bar", res.getValue());
 	}
-	
+
 	@Test
-	public void testChainAttrib(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/chainAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignSelfAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/selfAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(caller,res.getValue());
+
+		assertEquals(1, res.getValue());
 	}
-	
+
 	@Test
-	public void testChainDynamicAttrib(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/chainDynamicAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignLocalAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/localAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(caller,res.getValue());
+
+		assertEquals(2, res.getValue());
 	}
-	
+
 	@Test
-	public void testChainCall(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/chainCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignParamAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/paramAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		EObject newInstance = EcoreUtil.create(caller.eClass());
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(newInstance), parsedSemantics);
+
+		assertEquals(3, res.getValue());
+	}
+
+	@Test
+	public void testAssignResultAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/resultAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(caller,res.getValue());
+
+		assertEquals(4, res.getValue());
 	}
-	
+
 	@Test
-	public void testForEachSequence(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/forEachSequence.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignCallAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/callAttributeAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("012345",res.getValue());
+
+		assertEquals(5, res.getValue());
 	}
-	
+
 	@Test
-	public void testForEachReverseSequence(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/forEachReverseSequence.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSelfCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/selfCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("4321",res.getValue());
+
+		assertEquals(1, res.getValue());
 	}
-	
+
 	@Test
-	public void testForEachCollection(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/forEachCollection.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testLocalCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/localCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
+
+		assertEquals(2, res.getValue());
 	}
-	
+
 	@Test
-	public void testForEachEmpty(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/forEachEmptyCollection.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAttributeCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/attributeCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(0,res.getValue());
+
+		assertEquals(3, res.getValue());
 	}
-	
+
 	@Test
-	public void testWhile(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/while.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testDynamicAttributeCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/dynamicAttributeCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(10,res.getValue());
+
+		assertEquals(4, res.getValue());
 	}
-	
+
 	@Test
-	public void testIfTrue(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/ifTrue.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testParamCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/paramCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		EObject newInstance = EcoreUtil.create(caller.eClass());
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(newInstance), parsedSemantics);
+
+		assertEquals(5, res.getValue());
+	}
+
+	@Test
+	public void testParamValue()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/paramValue.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(1,res.getValue());
+
+		assertEquals(6, res.getValue());
 	}
-	
+
 	@Test
-	public void testIfFalse(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/ifFalse.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testResultCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/resultCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(0,res.getValue());
+
+		assertEquals(6, res.getValue());
 	}
-	
+
 	@Test
-	public void testElseTrue(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/elseTrue.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testChainAttrib()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/chainAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(1,res.getValue());
+
+		assertEquals(caller, res.getValue());
 	}
-	
+
 	@Test
-	public void testElseFalse(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/elseFalse.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testChainDynamicAttrib()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/chainDynamicAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
+
+		assertEquals(caller, res.getValue());
 	}
-	
+
 	@Test
-	public void testElseIf(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/elseIf.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testChainCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/chainCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("345",res.getValue());
+
+		assertEquals(caller, res.getValue());
 	}
-	
+
 	@Test
-	public void testAdd(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/add.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testForEachSequence()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/forEachSequence.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(3,res.getValue());
+
+		assertEquals("012345", res.getValue());
 	}
-	
+
 	@Test
-	public void testRemove(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/remove.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testForEachReverseSequence()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/forEachReverseSequence.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
+
+		assertEquals("4321", res.getValue());
 	}
-	
+
 	@Test
-	public void testLog(){
+	public void testForEachCollection()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/forEachCollection.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(2, res.getValue());
+	}
+
+	@Test
+	public void testForEachEmpty()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/forEachEmptyCollection.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(0, res.getValue());
+	}
+
+	@Test
+	public void testWhile()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/while.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(10, res.getValue());
+	}
+
+	@Test
+	public void testIfTrue()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/ifTrue.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(1, res.getValue());
+	}
+
+	@Test
+	public void testIfFalse()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/ifFalse.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(0, res.getValue());
+	}
+
+	@Test
+	public void testElseTrue()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/elseTrue.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(1, res.getValue());
+	}
+
+	@Test
+	public void testElseFalse()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/elseFalse.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(2, res.getValue());
+	}
+
+	@Test
+	public void testElseIf()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/elseIf.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals("345", res.getValue());
+	}
+
+	@Test
+	public void testAdd()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/add.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(3, res.getValue());
+	}
+
+	@Test
+	public void testRemove()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/remove.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+
+		assertEquals(2, res.getValue());
+	}
+
+	@Test
+	public void testLog()  throws ClosedALEInterpreterException {
 		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(outContent));
-		
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/log.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/log.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertEquals("foobar\n", outContent.toString());
-		
+
 		System.setOut(null);
-		
+
 	}
-	
+
 	@Test
-	public void testCreate(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/create.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testCreate()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/create.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertNotNull(res.getValue());
-		assertNotEquals(caller,res.getValue());
+		assertNotEquals(caller, res.getValue());
 		assertTrue(res.getValue() instanceof EObject);
-		assertTrue(((EObject)res.getValue()).eClass().getName().equals("ClassA"));
+		assertTrue(((EObject) res.getValue()).eClass().getName().equals("ClassA"));
 	}
-	
+
 	@Test
-	public void testService(){
+	public void testService()  throws ClosedALEInterpreterException {
 		try {
-			ServiceUtils.registerServices(
-					interpreter.getQueryEnvironment(),
-					ServiceUtils.getServices(interpreter.getQueryEnvironment(),	Class.forName("org.eclipse.emf.ecoretools.ale.core.interpreter.test.Service"))
-					);
+			ServiceUtils.registerServices(interpreter.getQueryEnvironment(),
+					ServiceUtils.getServices(interpreter.getQueryEnvironment(),
+							Class.forName("org.eclipse.emf.ecoretools.ale.core.interpreter.test.Service")));
 		} catch (ClassNotFoundException e) {
 			e.printStackTrace();
 		}
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/service.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/service.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("foobar:ClassA",res.getValue());
+
+		assertEquals("foobar:ClassA", res.getValue());
 	}
-	
+
 	@Test
-	public void testNewClass(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/newClass.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testNewClass()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/newClass.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertNotNull(res.getValue());
-		assertNotEquals(caller,res.getValue());
+		assertNotEquals(caller, res.getValue());
 		assertTrue(res.getValue() instanceof EObject);
-		assertEquals("NewRuntimeClass",((EObject)res.getValue()).eClass().getName());
+		assertEquals("NewRuntimeClass", ((EObject) res.getValue()).eClass().getName());
 	}
-	
+
 	@Test
-	public void testOppositeAssign(){
+	public void testOppositeAssign()  throws ClosedALEInterpreterException {
 		/*
 		 * Check NewClass to self
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/opposite.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/opposite.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof EObject);
-		assertNotEquals(caller,res.getValue());
-		assertEquals("NewClass",((EObject)res.getValue()).eClass().getName());
+		assertNotEquals(caller, res.getValue());
+		assertEquals("NewClass", ((EObject) res.getValue()).eClass().getName());
 	}
-	
+
 	@Test
-	public void testOppositeAssign2(){
+	public void testOppositeAssign2()  throws ClosedALEInterpreterException {
 		/*
 		 * Check self to NewClass
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/opposite2.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/opposite2.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof EObject);
-		assertEquals(caller,res.getValue());
+		assertEquals(caller, res.getValue());
 	}
-	
+
 	@Test
-	public void testOppositeAssign3(){
+	public void testOppositeAssign3()  throws ClosedALEInterpreterException {
 		/*
 		 * Check ClassA to self
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/opposite3.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/opposite3.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof EObject);
-		assertEquals(caller,res.getValue());
+		assertEquals(caller, res.getValue());
 	}
-	
+
 	@Test
-	public void testOppositeAssign4(){
+	public void testOppositeAssign4()  throws ClosedALEInterpreterException {
 		/*
 		 * Check NewClass to NewClass
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/opposite4.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/opposite4.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertNotNull(res.getValue());
-		assertNotEquals(caller,res.getValue());
+		assertNotEquals(caller, res.getValue());
 		assertEquals("obj1", res.getValue());
 	}
-	
+
 	@Test
-	public void testContainsDynamicEContainer(){
+	public void testContainsDynamicEContainer()  throws ClosedALEInterpreterException {
 		/*
 		 * Check eContainer()
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/containsDynamicEContainer.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/containsDynamicEContainer.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertNotNull(res.getValue());
 		assertEquals(caller, res.getValue());
 	}
-	
+
 	@Test
-	public void testContainsDoubelAssign(){
+	public void testContainsDoubelAssign()  throws ClosedALEInterpreterException {
 		/*
 		 * Check double assignment
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/containsDoubleAssign.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/containsDoubleAssign.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertNull(res.getValue());
 	}
-	
+
 	@Test
-	public void testContainsSelfEContainer(){
+	public void testContainsSelfEContainer()  throws ClosedALEInterpreterException {
 		/*
 		 * Check self.eContainer()
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/containsSelfEContainer.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/containsSelfEContainer.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof EObject);
-		assertEquals("NewClass", ((EObject)res.getValue()).eClass().getName());
+		assertEquals("NewClass", ((EObject) res.getValue()).eClass().getName());
 	}
-	
+
 	@Test
-	public void testContainsEContents(){
+	public void testContainsEContents()  throws ClosedALEInterpreterException {
 		/*
 		 * Check self.eContent()
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/containsEContents.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/containsEContents.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		Object value = res.getValue();
 		assertTrue(value instanceof List);
-		assertEquals(1,((List<?>)value).size());
-		
-		Object contained = ((List<?>)value).get(0);
+		assertEquals(1, ((List<?>) value).size());
+
+		Object contained = ((List<?>) value).get(0);
 		assertTrue(contained instanceof EObject);
-		assertEquals("NewClass", ((EObject)contained).eClass().getName());
+		assertEquals("NewClass", ((EObject) contained).eClass().getName());
 	}
-	
+
 	@Test
-	public void testContainsEAllContents(){
+	public void testContainsEAllContents()  throws ClosedALEInterpreterException {
 		/*
 		 * Check self.eAllContent()
 		 */
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/containsEAllContents.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/containsEAllContents.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA2.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		Object value = res.getValue();
 		assertTrue(value instanceof List);
-		assertEquals(4,((List<?>)value).size());
-		
-		Object elem1 = ((List<?>)value).get(0);
-		Object elem2 = ((List<?>)value).get(1);
-		Object elem3 = ((List<?>)value).get(2);
-		Object elem4 = ((List<?>)value).get(3);
-		
+		assertEquals(4, ((List<?>) value).size());
+
+		Object elem1 = ((List<?>) value).get(0);
+		Object elem2 = ((List<?>) value).get(1);
+		Object elem3 = ((List<?>) value).get(2);
+		Object elem4 = ((List<?>) value).get(3);
+
 		assertTrue(elem1 instanceof EObject);
-		assertEquals("ClassA", ((EObject)elem1).eClass().getName());
+		assertEquals("ClassA", ((EObject) elem1).eClass().getName());
 		assertTrue(elem2 instanceof EObject);
-		assertEquals("ClassA", ((EObject)elem2).eClass().getName());
+		assertEquals("ClassA", ((EObject) elem2).eClass().getName());
 		assertTrue(elem3 instanceof EObject);
-		assertEquals("NewClass", ((EObject)elem3).eClass().getName());
+		assertEquals("NewClass", ((EObject) elem3).eClass().getName());
 		assertTrue(elem4 instanceof EObject);
-		assertEquals("ClassA", ((EObject)elem4).eClass().getName());
+		assertEquals("ClassA", ((EObject) elem4).eClass().getName());
 	}
-	
+
 	@Test
-	public void testUniqueAssign(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/unique.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testUniqueAssign()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/unique.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertEquals(1, res.getValue());
 	}
-	
+
 	@Test
-	public void testManyRemove(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/removeDynamic.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testManyRemove()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/removeDynamic.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertEquals(1, res.getValue());
 	}
-	
+
 	@Test
-	public void testInitDynamicAttributeFailure(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/initDynamicAttributeFailure.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testInitDynamicAttributeFailure()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/initDynamicAttributeFailure.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("ClassA",((EObject)res.getValue()).eClass().getName());
+
+		assertEquals("ClassA", ((EObject) res.getValue()).eClass().getName());
 		interpreter.getLogger().diagnosticForHuman();
-		assertEquals("An error occured during initialization of an EObject", interpreter.getLogger().getLog().get(0).getMessage());
+		assertEquals("An error occured during initialization of an EObject",
+				interpreter.getLogger().getLog().get(0).getMessage());
 	}
-	
+
 	@Test
-	public void testECrossRef() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/crossRef.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testECrossRef()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/crossRef.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA3.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof List);
 		List<?> resValue = (List<?>) res.getValue();
-		assertEquals(1,resValue.size());
-		
+		assertEquals(1, resValue.size());
+
 		EObject elem1 = (EObject) resValue.get(0);
-		assertEquals("ClassA",elem1.eClass().getName());
+		assertEquals("ClassA", elem1.eClass().getName());
 		EStructuralFeature field = elem1.eClass().getEStructuralFeature("field");
-		assertEquals(0,elem1.eGet(field));
-		assertEquals(5,caller.eGet(field));
+		assertEquals(0, elem1.eGet(field));
+		assertEquals(5, caller.eGet(field));
 	}
-	
+
 	@Test
-	public void testECrossRefDynamic() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/crossRefDynamic.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testECrossRefDynamic()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/crossRefDynamic.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		EObject arg = interpreter.loadModel("model/ClassA3.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(arg), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof List);
 		List<?> resValue = (List<?>) res.getValue();
-		assertEquals(1,resValue.size());
-		
+		assertEquals(1, resValue.size());
+
 		EObject elem1 = (EObject) resValue.get(0);
-		assertEquals("ClassA",elem1.eClass().getName());
+		assertEquals("ClassA", elem1.eClass().getName());
 		EStructuralFeature field = elem1.eClass().getEStructuralFeature("field");
-		assertEquals(5,elem1.eGet(field));
-		assertEquals(0,caller.eGet(field));
+		assertEquals(5, elem1.eGet(field));
+		assertEquals(0, caller.eGet(field));
 	}
-	
+
 	@Test
-	public void testEGet() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/eGet.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testEGet()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/eGet.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA3.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(5,res.getValue());
+
+		assertEquals(5, res.getValue());
 	}
-	
+
 	@Test
-	public void testEGetDynamic() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/eGetDynamic.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testEGetDynamic()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/eGetDynamic.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA3.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(123,res.getValue());
+
+		assertEquals(123, res.getValue());
 	}
-	
+
 	@Test
-	public void testSelectedCall() {
-		Dsl environment = new Dsl(Arrays.asList("model/ABC.ecore"),Arrays.asList("input/eval/selectedCallMain.implem","input/eval/selectedCall1.implem","input/eval/selectedCall2.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSelectedCall()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/ABC.ecore"), Arrays.asList("input/eval/selectedCallMain.implem",
+				"input/eval/selectedCall1.implem", "input/eval/selectedCall2.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/B.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals("test.selectedCallOne.A.foo()\ntest.selectedCallOne.B.foo()\ntest.selectedCallTwo.A.foo()\ntest.selectedCallTwo.B.foo()",res.getValue());
+
+		assertEquals(
+				"test.selectedCallOne.A.foo()\ntest.selectedCallOne.B.foo()\ntest.selectedCallTwo.A.foo()\ntest.selectedCallTwo.B.foo()",
+				res.getValue());
 	}
-	
+
 	@Test
-	public void testSwitch() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/switch.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSwitch()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/switch.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
+
+		assertEquals(2, res.getValue());
 	}
-	
+
 	@Test
-	public void testSwitchEClassGuard() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/switchEClassGuard.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSwitchEClassGuard()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/switchEClassGuard.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
+
+		assertEquals(2, res.getValue());
 	}
-	
+
 	@Test
-	public void testSwitchBooleanGuard() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/switchBooleanGuard.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSwitchBooleanGuard()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/switchBooleanGuard.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(2,res.getValue());
+
+		assertEquals(2, res.getValue());
 	}
-	
+
 	@Test
-	public void testSwitchDefault() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/switchDefault.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSwitchDefault()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/switchDefault.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(1,res.getValue());
+
+		assertEquals(1, res.getValue());
 	}
-	
+
 	@Test
-	public void testSwitchBoth() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/switchBoth.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSwitchBoth()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/switchBoth.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(4,res.getValue());
+
+		assertEquals(4, res.getValue());
 	}
-	
+
 	@Test
-	public void testSwitchVarRef() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/switchVarRef.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testSwitchVarRef()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/switchVarRef.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(3,res.getValue());
+
+		assertEquals(3, res.getValue());
 	}
-	
+
 	@Test
-	public void testNoMain(){
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/nomain.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testNoMain()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/nomain.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(null,res.getValue());
+
+		assertEquals(null, res.getValue());
 		assertEquals("No operation with @main found", res.getDiagnostic().getMessage());
 	}
-	
+
 	@Test
-	public void testListener(){
+	public void testListener()  throws ClosedALEInterpreterException {
 		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(outContent));
 
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/attributeCall.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"), Arrays.asList("input/eval/attributeCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
-		
+
 		interpreter.addListener(new ServiceCallListener() {
 			@Override
 			public void preCall(IService service, Object[] arguments) {
-				System.out.println("In:"+service.getName());
+				System.out.println("In:" + service.getName());
 			}
-			
+
 			@Override
 			public void postCall(IService service, Object[] arguments, Object result) {
-				System.out.println("Out:"+service.getName());
+				System.out.println("Out:" + service.getName());
 			}
 		});
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(3,res.getValue());
+
+		assertEquals(3, res.getValue());
 		assertEquals("In:aqlFeatureAccess\nOut:aqlFeatureAccess\nIn:getSelf\nOut:getSelf\n", outContent.toString());
-		
+
 		System.setOut(null);
 	}
-	
+
 	@Test
-	public void testAssignDynamicCollectionAttribute() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/assignDynamicCollectionAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignDynamicCollectionAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/assignDynamicCollectionAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertEquals("1 1", res.getValue());
 	}
-	
+
 	@Test
-	public void testAssignCollectionAttribute() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/assignCollectionAttribute.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testAssignCollectionAttribute()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/assignCollectionAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertEquals("1 ClassA", res.getValue());
 	}
-	
+
 	@Test
-	public void testInsertLocalVariable() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/insertLocalVariable.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testInsertLocalVariable()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/insertLocalVariable.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof List);
-		assertEquals(3, ((List)res.getValue()).size());
-		assertEquals(caller.eClass(), ((EObject)((List)res.getValue()).get(0)).eClass());
-		assertEquals(caller.eClass(), ((EObject)((List)res.getValue()).get(1)).eClass());
-		assertEquals(caller.eClass(), ((EObject)((List)res.getValue()).get(2)).eClass());
+		assertEquals(3, ((List) res.getValue()).size());
+		assertEquals(caller.eClass(), ((EObject) ((List) res.getValue()).get(0)).eClass());
+		assertEquals(caller.eClass(), ((EObject) ((List) res.getValue()).get(1)).eClass());
+		assertEquals(caller.eClass(), ((EObject) ((List) res.getValue()).get(2)).eClass());
 	}
-	
+
 	@Test
-	public void testRemoveLocalVariable() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/removeLocalVariable.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testRemoveLocalVariable()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/removeLocalVariable.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
+
 		assertTrue(res.getValue() instanceof List);
-		assertEquals(2, ((List)res.getValue()).size());
-		assertEquals(caller.eClass(), ((EObject)((List)res.getValue()).get(0)).eClass());
-		assertEquals(caller.eClass(), ((EObject)((List)res.getValue()).get(1)).eClass());
+		assertEquals(2, ((List) res.getValue()).size());
+		assertEquals(caller.eClass(), ((EObject) ((List) res.getValue()).get(0)).eClass());
+		assertEquals(caller.eClass(), ((EObject) ((List) res.getValue()).get(1)).eClass());
 	}
-	
+
 	@Test
-	public void testCallMissingMethod() {
-		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),Arrays.asList("input/eval/callMissingMethod.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+	public void testCallMissingMethod()  throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/callMissingMethod.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		IEvaluationResult res = interpreter.eval(caller, Arrays.asList(), parsedSemantics);
-		
-		assertEquals(Diagnostic.WARNING, res.getDiagnostic().getSeverity());	
+
+		assertEquals(Diagnostic.WARNING, res.getDiagnostic().getSeverity());
 		assertEquals("An error occured during evaluation of a query", res.getDiagnostic().getMessage());
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/lookup/test/LookupTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/lookup/test/LookupTest.java
@@ -12,6 +12,7 @@ package org.eclipse.emf.ecoretools.ale.core.lookup.test;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -20,11 +21,13 @@ import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecoretools.ale.ALEInterpreter;
+import org.eclipse.emf.ecoretools.ale.ALEInterpreter.ClosedALEInterpreterException;
 import org.eclipse.emf.ecoretools.ale.core.parser.Dsl;
 import org.eclipse.emf.ecoretools.ale.core.parser.DslBuilder;
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult;
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.sirius.common.tools.api.interpreter.IInterpreterWithDiagnostic.IEvaluationResult;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,9 +39,16 @@ public class LookupTest {
 	public void setup() {
 		interpreter = new ALEInterpreter();
 	}
+
+	@After
+	public void release() throws IOException {
+		if (interpreter != null) {
+			interpreter.close();
+		}
+	}
 	
 	@Test
-	public void testInherits() {
+	public void testInherits()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/ABC.ecore"),Arrays.asList("input/lookup/inherits.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = interpreter.loadModel("model/A.xmi").getContents().get(0);
@@ -48,7 +58,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testInheritsWithParam() {
+	public void testInheritsWithParam()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/ABC.ecore"),Arrays.asList("input/lookup/inheritsWithParam.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = interpreter.loadModel("model/A.xmi").getContents().get(0);
@@ -58,7 +68,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testExtends() {
+	public void testExtends()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/ABC.ecore"),Arrays.asList("input/lookup/inherits.implem","input/lookup/extends.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = interpreter.loadModel("model/A.xmi").getContents().get(0);
@@ -68,7 +78,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testMultiInherits() {
+	public void testMultiInherits()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/multi.ecore"),Arrays.asList("input/lookup/multi.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = interpreter.loadModel("model/C.xmi").getContents().get(0);
@@ -78,7 +88,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testDoubleMultiInherits() {
+	public void testDoubleMultiInherits()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/doubleMulti.ecore"),Arrays.asList("input/lookup/doubleMulti.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("C");
@@ -88,7 +98,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testSimple() {
+	public void testSimple()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/simple.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("A");
@@ -98,7 +108,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testImplicitInherit() {
+	public void testImplicitInherit()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/simple.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("B");
@@ -108,7 +118,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testImplicitExtend() {
+	public void testImplicitExtend()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/implicitExtend.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("B");
@@ -118,7 +128,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testExplicitExtend() {
+	public void testExplicitExtend()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/explicitExtend.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("B");
@@ -128,7 +138,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testClosestExtend() {
+	public void testClosestExtend()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/implicitExtend.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("D");
@@ -138,7 +148,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testSimpleLowerType() {
+	public void testSimpleLowerType()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/simpleLowerType.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("A");
@@ -148,7 +158,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testSimpleLowerType2() {
+	public void testSimpleLowerType2()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/simpleLowerType.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("A");
@@ -158,7 +168,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testLowerType() {
+	public void testLowerType() throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/lowerType.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("B");
@@ -168,7 +178,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testLowerType2() {
+	public void testLowerType2()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/lowerType.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("B");
@@ -178,7 +188,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testLowerType3() {
+	public void testLowerType3()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/lowerType.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("A");
@@ -188,7 +198,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testLowerTypeInverted() {
+	public void testLowerTypeInverted()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/lowerTypeInverted.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("B");
@@ -198,7 +208,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testLowerTypeInverted2() {
+	public void testLowerTypeInverted2()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/diamon.ecore"),Arrays.asList("input/lookup/lowerTypeInverted.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = create("B");
@@ -208,7 +218,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testInheritGetter() {
+	public void testInheritGetter()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/ABC.ecore"),Arrays.asList("input/lookup/inheritGetter.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = interpreter.loadModel("model/B.xmi").getContents().get(0);
@@ -218,7 +228,7 @@ public class LookupTest {
 	}
 	
 	@Test
-	public void testInheritSetter() {
+	public void testInheritSetter()  throws ClosedALEInterpreterException {
 		Dsl environment = new Dsl(Arrays.asList("model/ABC.ecore"),Arrays.asList("input/lookup/inheritSetter.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		EObject caller = interpreter.loadModel("model/B.xmi").getContents().get(0);


### PR DESCRIPTION
This PR adds a close() method on ALEInterpreter

This allows to properly dispose the resource retained by the `queryEnvironment` and the `javaExtensions`.

The class extends AutoCloseable, so users of this class may use `try with resource`.

The method eval is protected against the use of closed interpreter by declaring that it can throw a ClosedALEInterpreterExcpetion.  This declaration also helps to know that the close method must be calle after use of the interpreter.

This PR should fix https://github.com/gemoc/ale-lang/issues/54 and contribute to fix memory while using the interpreter in other contexts.
