### PR TITLE
Enhance support for sequences

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -33,6 +33,7 @@ import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EParameter;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
 import org.eclipse.emf.ecoretools.ale.implementation.Block;
 import org.eclipse.emf.ecoretools.ale.implementation.ConditionalBlock;
@@ -118,9 +119,31 @@ public class MethodEvaluator {
 	}
 	
 	public Object caseVariableDeclaration(VariableDeclaration varDecl) throws CriticalFailure {
-		Object value = aqlEval(varDecl.getInitialValue());
+		Object value;
+		if (varDecl.getInitialValue() == null) {
+			value = defaultValueFor(varDecl).orElse(null);
+		}
+		else {
+			value = aqlEval(varDecl.getInitialValue());
+		}
 		variablesStack.peek().put(varDecl.getName(), value);
 		return null;
+	}
+	
+	private Optional<Object> defaultValueFor(VariableDeclaration varDecl) {
+		if (varDecl.getType() == EcorePackage.eINSTANCE.getEString()) {
+			return Optional.of("");
+		}
+		if (varDecl.getType() == EcorePackage.eINSTANCE.getEInt()) {
+			return Optional.of(0);
+		}
+		if (varDecl.getType() == EcorePackage.eINSTANCE.getEEList()) {
+			return Optional.of(new BasicEList<>());
+		}
+		if (varDecl.getType() == EcorePackage.eINSTANCE.getEBoolean()) {
+			return Optional.of(false);
+		}
+		return Optional.empty();
 	}
 	
 	public Object caseVariableAssignment(VariableAssignment varAssign) throws CriticalFailure {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/services/DynamicEObjectFeatureAccess.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/services/DynamicEObjectFeatureAccess.java
@@ -34,6 +34,8 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.DynamicFeatureRegistry;
+import org.eclipse.emf.ecoretools.ale.core.validation.IConvertType;
+import org.eclipse.emf.ecoretools.ale.core.validation.impl.ConvertType;
 import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
 
 //FIXME: copy past from EObjectServices.EObjectFeatureAccess because it's private
@@ -130,13 +132,8 @@ public class DynamicEObjectFeatureAccess extends JavaMethodService {
 				if (feature == null) {
 					result.add(services.nothing(UNKNOWN_FEATURE, featureName, eClass.getName()));
 				} else {
-					final EClassifierType featureBasicType = new EClassifierType(queryEnvironment,
-							feature.getEType());
-					if (feature.isMany()) {
-						result.add(new SequenceType(queryEnvironment, featureBasicType));
-					} else {
-						result.add(featureBasicType);
-					}
+					IConvertType convert = new ConvertType(queryEnvironment);
+					result.add(convert.toAQL(feature));
 				}
 			}
 		}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/services/ServiceCallListener.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/services/ServiceCallListener.java
@@ -11,11 +11,19 @@
 package org.eclipse.emf.ecoretools.ale.core.interpreter.services;
 
 import org.eclipse.acceleo.query.runtime.IService;
+import org.eclipse.emf.ecoretools.ale.core.interpreter.ALEEngine;
 
+/**
+ * Listener called by the {@link ALEEngine} when an AQL service is invoked. 
+ */
 public interface ServiceCallListener {
 	
-	public void preCall(IService service, Object[] arguments);
+	default void preCall(IService service, Object[] arguments) {
+		// does nothing by default
+	}
 	
-	public void postCall(IService service, Object[] arguments, Object result);
+	default void postCall(IService service, Object[] arguments, Object result) {
+		// does nothing by default
+	}
 	
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java
@@ -107,10 +107,16 @@ public class ModelBuilder {
 		
 		String name;
 		EClassifier type;
+		EGenericType genericType;
 		
 		public Parameter(String name, EClassifier type) {
+			this(name, type, null);
+		}
+		
+		public Parameter(String name, EClassifier type, EGenericType genericType) {
 			this.name = name;
 			this.type = type;
+			this.genericType = genericType;
 		}
 		
 		public String getName() {
@@ -119,6 +125,10 @@ public class ModelBuilder {
 		
 		public EClassifier getType() {
 			return type;
+		}
+		
+		public Optional<EGenericType> getGenericType() {
+			return Optional.ofNullable(genericType);
 		}
 	}
 	
@@ -148,6 +158,9 @@ public class ModelBuilder {
 			EParameter opParam = ecoreFactory.createEParameter();
 			opParam.setName(p.getName());
 			opParam.setEType(p.getType());
+			p.getGenericType()
+			 .ifPresent(t -> opParam.getEGenericType().getETypeArguments().add(t));
+			
 			operation.getEParameters().add(opParam);
 		});
 		
@@ -183,7 +196,10 @@ public class ModelBuilder {
 	
 	
 	public Parameter buildParameter(RTypeContext type, String name) {
-		return new Parameter(name, resolve(type));
+		EClassifier classifier = resolve(type);
+		EGenericType genericType = resolveGenericTypeParameter(classifier, type.getText()).orElse(null);
+		
+		return new Parameter(name, classifier, genericType);
 	}
 	
 	public Attribute buildAttribute(EClass fragment, String name, RExpressionContext exp, RTypeContext type, int lowerBound, int upperBound, boolean isContainment, boolean isUnique, String opposite, ParseResult<ModelUnit> parseRes) {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -39,6 +39,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EParameter;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.EvalEnvironment;
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult;
+import org.eclipse.emf.ecoretools.ale.core.validation.impl.ConvertType;
 import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
 import org.eclipse.emf.ecoretools.ale.implementation.Block;
 import org.eclipse.emf.ecoretools.ale.implementation.ConditionalBlock;
@@ -92,9 +93,15 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 	IQueryEnvironment qryEnv;
 	List<IValidator> validators;
 	
+	/**
+	 * Convert EMF types to AQL ones
+	 */
+	private IConvertType convert;
+	
 	public BaseValidator(IQueryEnvironment qryEnv, List<IValidator> validators) {
 		this.qryEnv = qryEnv;
 		this.expValidator = new AstValidator(new ValidationServices(qryEnv));
+		this.convert = new ConvertType(qryEnv);
 		
 		this.validators = new ArrayList<>();
 		validators.forEach(validator -> {
@@ -217,8 +224,8 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 			for (EParameter param : mtd.getOperationRef().getEParameters()) {
 				Set<IType> previousDeclaration = methodScope.get(param.getName());
 				if(previousDeclaration == null) {
-					EClassifierType type = new EClassifierType(qryEnv, param.getEType());
-					methodScope.put(param.getName(), Sets.newHashSet(type));
+					IType aqlParameterType = convert.toAQL(param);
+					methodScope.put(param.getName(), Sets.newHashSet(aqlParameterType));
 				}
 			}
 		}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -507,6 +507,9 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 		if(validRes != null) {
 			Set<IType> types = validRes.getPossibleTypes(exp);
 			for (IType type : types) {
+				// FIXME [Refactor] Here we gather the generic type of a collection.
+				//					I am pretty sure this is needed/duplicated elsewhere
+				//					so we should consider putting this at a common place
 				if(type instanceof AbstractCollectionType) {
 					res.add(((AbstractCollectionType)type).getCollectionType());
 				}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
@@ -14,7 +14,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 
-import org.eclipse.acceleo.query.runtime.IQueryEnvironment;
+import org.eclipse.acceleo.query.runtime.IReadOnlyQueryEnvironment;
 import org.eclipse.acceleo.query.validation.type.EClassifierType;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.acceleo.query.validation.type.NothingType;
@@ -28,9 +28,9 @@ import org.eclipse.emf.ecoretools.ale.core.validation.IConvertType;
 
 public final class ConvertType implements IConvertType {
 	
-	private final IQueryEnvironment queryEnvironment;
+	private final IReadOnlyQueryEnvironment queryEnvironment;
 	
-	public ConvertType(IQueryEnvironment queryEnvironment) {
+	public ConvertType(IReadOnlyQueryEnvironment queryEnvironment) {
 		this.queryEnvironment = requireNonNull(queryEnvironment, "queryEnvironment");
 	}
 	

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/initLocalVariables.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/initLocalVariables.implem
@@ -1,0 +1,17 @@
+behavior test.containattributes;
+
+open class Mix {
+
+	@main
+	def void main() {
+		Integer localInt;
+		Boolean localBool;
+		String localString;
+		Sequence(String) localStrings;
+		
+		self.int := localInt;
+		self.bool := localBool;
+		self.string := localString;
+		self.strings := localStrings;
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/callMethodTakingSequence.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/callMethodTakingSequence.implem
@@ -1,0 +1,14 @@
+behavior test.foreach;
+open class EClass {
+
+	0..* String stringNumbers := Sequence{'1', '2', '3'};
+
+	@main
+	def void main(){
+		Sequence(Integer) numbers := self.asInt(self.stringNumbers);
+	}
+	
+	def Sequence(Integer) asInt(Sequence(String) numbers) {
+		result := numbers->collect(number | number.toInteger());
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/forEachIntRange.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/forEachIntRange.implem
@@ -1,0 +1,7 @@
+behavior test.foreach;
+open class EClass {
+	def void op(){
+		for(i in [0..10]){
+		}
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/forEachSequence.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/forEachSequence.implem
@@ -1,9 +1,31 @@
 behavior test.foreach;
 open class EClass {
+
+	Sequence(Integer) numbers;
+
 	def void op(){
+	
+		// Variable
+	
 		Sequence(String) local := Sequence{'val1','val2'};
 		for(i in local){
 			String s := i;
+		}
+		
+		// Sequence in extension
+		
+		for (name in Sequence{'John', 'Smith'}) {
+			String userName := name;
+			userName.log();
+		}
+		
+		// Feature
+		
+		self.numbers := Sequence{1, 2, 3};
+		Integer sum := 0;
+		
+		for (number in self.numbers) {
+			sum += number;
 		}
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/model/Mix.xmi
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/model/Mix.xmi
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<attributesofdifferenttypes:Mix xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:attributesofdifferenttypes="http://test/attributesofdifferenttypes"
+    xsi:schemaLocation="http://test/attributesofdifferenttypes attributesOfDifferentTypes.ecore"/>

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/model/attributesOfDifferentTypes.ecore
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/model/attributesOfDifferentTypes.ecore
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="attributesofdifferenttypes" nsURI="http://test/attributesofdifferenttypes"
+    nsPrefix="attributesofdifferenttypes">
+  <eClassifiers xsi:type="ecore:EClass" name="Mix">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="int" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"
+        defaultValueLiteral="42"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="bool" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
+        defaultValueLiteral="false"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="string" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+        defaultValueLiteral="some sentence"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="strings" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
@@ -17,14 +17,19 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.acceleo.query.runtime.IService;
 import org.eclipse.acceleo.query.runtime.ServiceUtils;
+import org.eclipse.acceleo.query.validation.type.SequenceType;
+import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -53,7 +58,7 @@ public class EvalTest {
 	}
 
 	@After
-	public void release() throws IOException {
+	public void release() {
 		if (interpreter != null) {
 			interpreter.close();
 		}
@@ -890,6 +895,20 @@ public class EvalTest {
 		interpreter.getLogger().diagnosticForHuman();
 		assertEquals("An error occured during initialization of an EObject",
 				interpreter.getLogger().getLog().get(0).getMessage());
+	}
+	
+	@Test
+	public void testInitLocalVariable() throws ClosedALEInterpreterException {
+		Dsl environment = new Dsl(Arrays.asList("model/attributesOfDifferentTypes.ecore"), Arrays.asList("input/eval/initLocalVariables.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		interpreter.eval(caller, Arrays.asList(), parsedSemantics);
+		
+		assertEquals("int should be initialized to 0", 0, caller.eGet(caller.eClass().getEStructuralFeature("int")));
+		assertEquals("bool should be initialized to false", false, caller.eGet(caller.eClass().getEStructuralFeature("bool")));
+		assertEquals("string should be initialized to an empty string", "", caller.eGet(caller.eClass().getEStructuralFeature("string")));
+		assertEquals("sequence should be initialized to an empty sequence", new BasicEList<>(), caller.eGet(caller.eClass().getEStructuralFeature("strings")));
 	}
 
 	@Test

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -1146,11 +1146,12 @@ public class TypeValidatorTest {
 	}
 	
 	/*
-	 * Test ForEach expression is a Collection
+	 * Test that for-each loops accept integer ranges:
+	 * 		for (i in [0..10])
 	 */
 	@Test
-	public void testForEachCollection() {
-		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/forEachCollection.implem"));
+	public void testForEachIntegerRange() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/forEachIntRange.implem"));
 		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
 		
 		
@@ -1191,7 +1192,7 @@ public class TypeValidatorTest {
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
-		assertEquals(0, msg.size());
+		assertEquals("should have no errors but was: " + msg, 0, msg.size());
 	}
 	
 	/*

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -959,8 +959,8 @@ public class TypeValidatorTest {
 		assertEquals(4, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 75, 77, "[java.lang.Integer] cannot be added to [ecore::EString] (expected [ecore::EString])", msg.get(0));
 		assertMsgEquals(ValidationMessageLevel.ERROR, 111, 117, "[ecore::EBoolean] does not support the '+=' operator", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 179, 187, "[java.lang.String] cannot be added to [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(2));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 201, 222, "[Collection(java.lang.Boolean)] cannot be added to [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 179, 187, "[java.lang.String] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 201, 222, "[Collection(java.lang.Boolean)] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(3));
 	}
 	
 	/**
@@ -993,8 +993,8 @@ public class TypeValidatorTest {
 		assertEquals(4, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 75, 79, "[java.lang.String] cannot be removed from [ecore::EInt] (expected [ecore::EInt])", msg.get(0));
 		assertMsgEquals(ValidationMessageLevel.ERROR, 113, 119, "[ecore::EBoolean] does not support the '-=' operator", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 181, 189, "[java.lang.String] cannot be removed from [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(2));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 203, 224, "[Collection(java.lang.Boolean)] cannot be removed from [Collection(java.lang.Integer)] (expected [Collection(java.lang.Integer),java.lang.Integer])", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 181, 189, "[java.lang.String] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 203, 224, "[Collection(java.lang.Boolean)] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(3));
 	}
 	
 	@Test
@@ -1702,6 +1702,21 @@ public class TypeValidatorTest {
 		
 		assertEquals(1, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 110, 132, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
+	}
+	
+	/**
+	 * Test that an operation can take a sequence as parameter and use it freely
+	 */
+	@Test
+	public void testCallMethodTakingASequence() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/callMethodTakingSequence.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals("no error was expected but got: " + msg, 0, msg.size());
 	}
 	
 


### PR DESCRIPTION
Improve management of `Sequence` instances by fixing the following bugs:

 - #3 — Sequence cannot be used in operations
 - #10 — Sequences cannot be used in _for each_ loops
 - #20 — Methods taking parameters of type Sequence cannot be called
 - #42 — Empty Sequence cannot be declared
 - #56 — Local variables cannot be declared without an initial value
 - #75 — Attributes of type Sequence cannot be initialized

Basically, the following code is now legal:
```ale
open class EClass {

     0..* String stringNumbers := Sequence{'1', '2', '3'};

    @main
    def void main(){
        Sequence(Integer) numbers := self.asInt(self.stringNumbers);
    }
	
    def Sequence(Integer) asInt(Sequence(String) numbers) {
        result := numbers->collect(number | number.toInteger());
    }
}
```

This PR contributes to #74 by taking the following approach:
 - EMF types (e.g. `EList`) are only used to parse the program & build the AST
 - EMF types are converted into AQL types (e.g. `Sequence`) by the type checker
 - the type checker mainly relies on AQL types to check the cohesion of types
