### PR TITLE
[Editor] Autocomplete attributes and methods of "self"

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleUiModule.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleUiModule.xtend
@@ -4,10 +4,16 @@
 package org.eclipse.emf.ecoretools.ui
 
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.emf.ecoretools.ui.contentassist.AleTemplateProposalProvider
 
 /**
  * Use this class to register components to be used within the Eclipse IDE.
  */
 @FinalFieldsConstructor
 class AleUiModule extends AbstractAleUiModule {
+	
+	override bindITemplateProposalProvider() {
+		return typeof(AleTemplateProposalProvider)
+	}
+	
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleProposalProvider.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleProposalProvider.xtend
@@ -20,6 +20,9 @@ import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
 import org.eclipse.emf.ecoretools.ale.ALEInterpreter
+import org.eclipse.emf.ecoretools.ale.BehavioredClass
+import org.eclipse.emf.ecoretools.ale.ExtendedClass
+import org.eclipse.emf.ecoretools.ale.VarRef
 import org.eclipse.emf.ecoretools.ale.core.parser.DslBuilder
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult
 import org.eclipse.emf.ecoretools.ale.core.validation.ALEValidator
@@ -27,33 +30,176 @@ import org.eclipse.emf.ecoretools.ale.implementation.Block
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit
 import org.eclipse.emf.workspace.util.WorkspaceSynchronizer
 import org.eclipse.jface.viewers.StyledString
+import org.eclipse.jface.viewers.StyledString.Styler
+import org.eclipse.swt.graphics.TextStyle
 import org.eclipse.xtext.Assignment
+import org.eclipse.xtext.Keyword
 import org.eclipse.xtext.RuleCall
 import org.eclipse.xtext.nodemodel.INode
 import org.eclipse.xtext.nodemodel.impl.AbstractNode
 import org.eclipse.xtext.nodemodel.impl.CompositeNode
 import org.eclipse.xtext.nodemodel.impl.CompositeNodeWithSemanticElement
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher
 
+import static extension org.eclipse.emf.ecoretools.ui.contentassist.TypeUtils.*
+
+/**
+ * Provides autocomplete for ALE.
+ * <p>
+ * Currently only autocomplete {@code self}'s attributes.
+ */
 class AleProposalProvider extends AbstractAleProposalProvider {
 	
-	override completeExpression_Feature(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		val candidate = getOffsetPrefix(context)
-		addProposals(candidate,model,context,acceptor)
-//		acceptor.accept(doCreateProposal("[DEBUG] feature", null, null, getPriorityHelper().getDefaultPriority()+1,context))
+	val matcher = new PrefixMatcher {
+		override isCandidateMatchingPrefix(String name, String prefix) {
+			if (prefix.isEmpty) {
+				return true;
+			}
+			if (name.startsWith(prefix)) {
+				return true;
+			}
+			if (name.contains(prefix)) {
+				return true;
+			}
+			return false
+		}
+	}
+	
+	val attributeNameStyler = new Styler() {
+		override applyStyles(TextStyle textStyle) {
+			// keep default style
+		}
+	}
+	
+	val attributeTypeStyler = StyledString.QUALIFIER_STYLER
+	
+	val matchingCharactersStyler = new Styler() {
+		override applyStyles(TextStyle textStyle) {
+			// Actually I'd like to use bold but found no way...
+		}
+	}
+	
+	override completeKeyword(Keyword keyword, ContentAssistContext contentAssistContext, ICompletionProposalAcceptor acceptor) {
+		// Prevent Xtext from proposing keywords all the time (especially when inappropriate)
+        return;
+    }
+    
+    override completeRuleCall(RuleCall object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+    	// Prevent Xtext from proposing unexpected proposals (such as '1')
+    	return
+    }
+	
+	override completeExpression_Feature(EObject element, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+		val prefix = getOffsetPrefix(context)
+		
+		if (prefix.startsWith("self.") || (element instanceof VarRef && ((element as VarRef).ID == "self"))) {
+			val typed = prefix.contains('.') ? prefix.substring(prefix.indexOf('.') + 1) : prefix
+			var clazz = element.enclosingBehavioredClass
+			
+			// Autocomplete attributes declared within the ALE script
+			
+			clazz.attributes
+				 .filter[attribute | matcher.isCandidateMatchingPrefix(attribute.name, typed)]
+				 .forEach[attribute |
+					val name = attribute.name 
+					val type = attribute.type.asString
+					val styledText = new StyledString(name + " : " + type)
+					/*
+					 * Style attribute's name
+					 */
+					styledText.setStyle(0, attribute.name.length, attributeNameStyler);
+					/*
+					 * Style attribute's type
+					 */
+					styledText.setStyle(styledText.length - type.length, type.length, attributeTypeStyler);
+					/*
+					 * Outline the matching characters
+					 */
+					val matchingCharactersIndex = name.indexOf(typed)
+					styledText.setStyle(matchingCharactersIndex, typed.length, matchingCharactersStyler)
+					
+					val completion = doCreateProposal(name, styledText, null, getPriorityHelper().getDefaultPriority(), context)
+					if (completion instanceof ConfigurableCompletionProposal) {
+						completion.matcher = matcher;
+					}
+					acceptor.accept(completion)
+				 ]
+				 
+			// Autocomplete features declared in the Ecore model
+				 
+			if (clazz instanceof ExtendedClass) {
+				val extendedClassInEcore = clazz as ExtendedClass
+				val semantics = getSemantics(element, context);
+				val extendedClassInAleScript = semantics.filter[unit | unit.root !== null]
+						          						.map[unit | unit.root]
+						          						.flatMap[root | root.classExtensions]
+						          						.findFirst[ext | extendedClassInEcore.name == ext.baseClass.name]
+						          
+				extendedClassInAleScript.baseClass.EStructuralFeatures
+										.filter[feature | matcher.isCandidateMatchingPrefix(feature.name, typed)]
+										.forEach[feature |
+											val name = feature.name 
+											val type = feature.typeAsString
+											val styledText = new StyledString(name + " : " + type)
+											/*
+											 * Style attribute's name
+											 */
+											styledText.setStyle(0, feature.name.length, attributeNameStyler)
+											/*
+											 * Style attribute's type
+											 */
+											styledText.setStyle(styledText.length - type.length, type.length, attributeTypeStyler)
+											/*
+											 * Outline the matching characters
+											 */
+											val matchingCharactersIndex = name.indexOf(typed)
+											styledText.setStyle(matchingCharactersIndex, typed.length, matchingCharactersStyler)
+											 
+											val completion = doCreateProposal(name, styledText, null, getPriorityHelper().getDefaultPriority(), context)
+											if (completion instanceof ConfigurableCompletionProposal) {
+												completion.matcher = matcher
+											}
+											acceptor.accept(completion)
+										]
+			}
+		}
+	}
+	
+	def getSemantics(EObject model, ContentAssistContext context) {
+		/*
+		 * Metamodel input
+		 */
+		val IFile aleFile = WorkspaceSynchronizer.getFile(model.eResource);
+		val IPath dslPath = aleFile.getFullPath().removeFileExtension().addFileExtension("ecore");
+    	val rs = new ResourceSetImpl();
+    	rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put("*", new XMIResourceFactoryImpl());
+    	val ecorePkgs = DslBuilder.load(dslPath.toString,rs);
+		
+		/*
+		 * ALE input
+		 */
+		val stream = new ByteArrayInputStream(context.document.get().getBytes(StandardCharsets.UTF_8));
+		
+		/*
+		 * Parse result
+		 */
+		val ALEInterpreter interpreter = new ALEInterpreter();
+		val List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(ecorePkgs,Arrays.asList(stream));
+		
+		return parsedSemantics;
 	}
 	
 	override completeExpression_Name(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		val candidate = getOffsetPrefix(context)
-		addProposals(candidate,model,context,acceptor)
+//		addProposals(candidate,model,context,acceptor)
 //		acceptor.accept(doCreateProposal("[DEBUG] name", null, null, getPriorityHelper().getDefaultPriority()+1,context))
 	}
 	
 	override complete_expression(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		val candidate = getOffsetPrefix(context)
-		addProposals(candidate,model,context,acceptor)
+//		addProposals(candidate,model,context,acceptor)
 //		acceptor.accept(doCreateProposal("[DEBUG] expression", null, null, getPriorityHelper().getDefaultPriority()+1,context))
 	}
 	
@@ -86,7 +232,7 @@ class AleProposalProvider extends AbstractAleProposalProvider {
 			/*
 	    	 * Register services
 	    	 */
-	    	val List<java.lang.String> services = 
+	    	val List<String> services = 
 	    		parsedSemantics
 		    	.map[getRoot()]
 		    	.filterNull
@@ -306,5 +452,13 @@ class AleProposalProvider extends AbstractAleProposalProvider {
 			return context.document.get(startOffset,context.offset-startOffset)
 		}
 		return ""
+	}
+	
+	private def enclosingBehavioredClass(EObject element) {
+		var clazz = element.eContainer
+		while (!(clazz instanceof BehavioredClass) && clazz !== null) {
+			clazz = clazz.eContainer
+		}
+		return clazz as BehavioredClass
 	}
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleTemplateProposal.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleTemplateProposal.xtend
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ui.contentassist
+
+import org.eclipse.jface.text.BadLocationException
+import org.eclipse.jface.text.DocumentEvent
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.text.IRegion
+import org.eclipse.jface.text.templates.Template
+import org.eclipse.jface.text.templates.TemplateContext
+import org.eclipse.swt.graphics.Image
+import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher
+import org.eclipse.xtext.ui.editor.templates.XtextTemplateProposal
+
+/**
+ * A template proposal that uses a {@link PrefixMatcher} to determine
+ * whether its template should be shown.
+ */
+class AleTemplateProposal extends XtextTemplateProposal {
+	
+	/**
+	 * Used to test whether the template should be shown.
+	 */
+	val PrefixMatcher matcher		
+	
+	new(PrefixMatcher matcher, Template template, TemplateContext context, IRegion region, Image image, int relevance) {
+		super(template, context, region, image, relevance)
+		this.matcher = matcher			
+	}
+	
+	override validate(IDocument document, int offset, DocumentEvent event) {
+		try {
+			val replaceOffset= getReplaceOffset();
+			if (offset >= replaceOffset) {
+				val String content= document.get(replaceOffset, offset - replaceOffset);
+				return matcher.isCandidateMatchingPrefix(template.getName(), content.toLowerCase());
+			}
+		} catch (BadLocationException e) {
+			// concurrent modification - ignore
+		}
+		return false;
+		
+	}
+	
+	override getDisplayString() {
+		// Override to remove the leading "-" shown by default
+		// (template's description is supposed to be displayed after it)
+		//
+		return getTemplate().getName()
+	}
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleTemplateProposalProvider.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleTemplateProposalProvider.xtend
@@ -1,0 +1,284 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ui.contentassist
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.util.Arrays
+import java.util.List
+import javax.inject.Inject
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.IPath
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
+import org.eclipse.emf.ecoretools.ale.ALEInterpreter
+import org.eclipse.emf.ecoretools.ale.BehavioredClass
+import org.eclipse.emf.ecoretools.ale.Block
+import org.eclipse.emf.ecoretools.ale.ExtendedClass
+import org.eclipse.emf.ecoretools.ale.VarRef
+import org.eclipse.emf.ecoretools.ale.core.parser.DslBuilder
+import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult
+import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit
+import org.eclipse.emf.workspace.util.WorkspaceSynchronizer
+import org.eclipse.jface.text.templates.ContextTypeRegistry
+import org.eclipse.jface.text.templates.Template
+import org.eclipse.jface.text.templates.TemplateContext
+import org.eclipse.jface.text.templates.persistence.TemplateStore
+import org.eclipse.xtext.nodemodel.INode
+import org.eclipse.xtext.nodemodel.impl.AbstractNode
+import org.eclipse.xtext.nodemodel.impl.CompositeNode
+import org.eclipse.xtext.nodemodel.impl.CompositeNodeWithSemanticElement
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext
+import org.eclipse.xtext.ui.editor.contentassist.ITemplateAcceptor
+import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher
+import org.eclipse.xtext.ui.editor.templates.ContextTypeIdHelper
+import org.eclipse.xtext.ui.editor.templates.DefaultTemplateProposalProvider
+import org.eclipse.xtext.ui.editor.templates.XtextTemplateContext
+
+import static extension org.eclipse.emf.ecoretools.ui.contentassist.TypeUtils.*
+
+/**
+ * Dynamically provides templates for ALE's proposal provider.
+ * <p>
+ * Templates are used to provide autocomplete for operations: unlike bare
+ * proposals templates can declare 'stakeholders' which make easier for the
+ * user to type operations' parameters. 
+ */
+class AleTemplateProposalProvider extends DefaultTemplateProposalProvider {
+	
+	/**
+	 * Avoid duplicated templates
+	 */
+	val matcher = new PrefixMatcher {
+		override isCandidateMatchingPrefix(String name, String prefix) {
+			val cleanName = name.toLowerCase
+			val cleanPrefix = prefix.toLowerCase
+			
+			if (cleanPrefix.isEmpty) {
+				return true;
+			}
+			if (cleanName.startsWith(cleanPrefix)) {
+				return true;
+			}
+			if (cleanName.contains(cleanPrefix)) {
+				return true;
+			}
+			return false
+		}
+	}
+	
+	@Inject
+	new(TemplateStore templateStore, ContextTypeRegistry registry, ContextTypeIdHelper helper) {
+		super(templateStore, registry, helper)
+	}
+	
+	override createTemplates(TemplateContext templateContext, ContentAssistContext context, ITemplateAcceptor acceptor) {
+		if (templateContext instanceof XtextTemplateContext) {
+			val prefix = context.offsetPrefix.trim
+			val element = context.currentModel
+			
+			/*
+			 * Autocomplete self.<typed>
+			 */
+			if (prefix.startsWith("self.") || (element instanceof VarRef && ((element as VarRef).ID == "self"))) {
+				val typed = prefix.contains('.') ? prefix.substring(prefix.indexOf('.') + 1) : prefix
+				var clazz = element.enclosingBehavioredClass
+				
+				// Used to ensure that only one template is created for overridden operations (which are defined both in Ecore and ALE)
+				val operationsProcessed = newArrayList()
+				 
+				// Autocomplete methods declared within the Ecore model
+				
+				if (clazz instanceof ExtendedClass) {
+					val extendedClassInEcore = clazz as ExtendedClass
+					val semantics = getSemantics(element, context);
+					val extendedClassInAleScript = semantics.filter[unit | unit.root !== null]
+							          						.map[unit | unit.root]
+							          						.flatMap[root | root.classExtensions]
+							          						.findFirst[ext | extendedClassInEcore.name == ext.baseClass.name]
+							          							
+					extendedClassInAleScript.baseClass
+											.EOperations
+											.filter[operation | matcher.isCandidateMatchingPrefix(operation.name, typed)]
+											.forEach[operation |
+												val text = operation.name + "(" + operation.EParameters.map[param | param.EType.name + " " + param.name].join(", ") + ") : " + operation.EType.name
+						
+												val template = new Template(text, "", text, text, false);
+												val proposal = doCreateProposal(template, templateContext, context, getImage(template), getRelevance(template))
+						
+												val fProposal = new AleTemplateProposal(matcher, template, templateContext, context.replaceRegion, proposal.image, proposal.relevance)
+												acceptor.accept(fProposal)
+												
+												operationsProcessed += text
+											]
+				}
+				 
+				// Autocomplete methods declared within the ALE script
+					 
+				clazz.operations
+					 .filter[operation | matcher.isCandidateMatchingPrefix(operation.name, typed)]
+					 .forEach[operation |
+						val templateName = operation.name + "(" + operation.params.map[param | param.type.asString + " " + param.name].join(", ") + ") : " + operation.type.asString
+
+						// The operations is overridden & a template has already been created						
+						if (operationsProcessed.contains(templateName)) {
+							return
+						}
+						val templatePattern = operation.name + "(" + operation.params.map[param | "${" + param.name + "}"].join(", ") + ")"
+
+						val template = new Template(templateName, "", templateName, templatePattern, false);
+						val proposal = doCreateProposal(template, templateContext, context, getImage(template), getRelevance(template))
+
+						val fProposal = new AleTemplateProposal(matcher, template, templateContext, context.replaceRegion, proposal.image, proposal.relevance)
+						acceptor.accept(fProposal)
+					 ]
+					 
+			}
+		}
+	}
+	
+	def getSemantics(EObject model, ContentAssistContext context) {
+		/*
+		 * Metamodel input
+		 */
+		val IFile aleFile = WorkspaceSynchronizer.getFile(model.eResource);
+		val IPath dslPath = aleFile.getFullPath().removeFileExtension().addFileExtension("ecore");
+    	val rs = new ResourceSetImpl();
+    	rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put("*", new XMIResourceFactoryImpl());
+    	val ecorePkgs = DslBuilder.load(dslPath.toString,rs);
+		
+		/*
+		 * ALE input
+		 */
+		val stream = new ByteArrayInputStream(context.document.get().getBytes(StandardCharsets.UTF_8));
+		
+		/*
+		 * Parse result
+		 */
+		val ALEInterpreter interpreter = new ALEInterpreter();
+		val List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(ecorePkgs,Arrays.asList(stream));
+		
+		return parsedSemantics;
+	}
+	
+	private def enclosingBehavioredClass(EObject element) {
+		var clazz = element.eContainer
+		while (!(clazz instanceof BehavioredClass) && clazz !== null) {
+			clazz = clazz.eContainer
+		}
+		return clazz as BehavioredClass
+	}
+	
+	/**
+	 * Find the Block node containing this node
+	 * 
+	 * Return null if not found
+	 */
+	private def CompositeNode getBlockNode(INode node) {
+		val debugDump = NodeModelUtils.compactDump(node.rootNode,true)
+		var current = node;
+		while(current != null) {
+			if(current instanceof CompositeNodeWithSemanticElement) {
+				if(current.semanticElement instanceof Block){
+					return current;
+				}
+			}
+			current = current.parent
+		}
+		return null;
+	}
+	
+	/**
+	 * Find the Statement node at the offset
+	 * 
+	 * Return null if not found
+	 */
+	private def AbstractNode findStatementNode(INode node, int offset) {
+		val block = getBlockNode(node)
+		//val debugDump = NodeModelUtils.compactDump(block,true)
+		if(block != null) {
+			val candidate = block.basicGetChildren.findFirst[child |
+				child.textRegion.contains(offset)
+			]
+			return candidate;
+		}
+		return null;
+	}
+	
+	/**
+	 * Assuming {@link text} is a statement, try to find the start of the expression around the offset
+	 */
+	private def int findStart(String text, int offset) {
+		
+		/*
+		 * Assign case
+		 */
+		var i = offset
+		while(i > 0) {
+			val frame = text.substring(i-1,i+1);
+			if(frame == ':=' || frame == '+=' || frame == '-=' || frame == 'in') {
+				if(i == offset) {
+					return offset;
+				}
+				else {
+					return i + 1;
+				}
+			}
+			i--
+		}
+		
+		/*
+		 * While case
+		 */
+		val whileIndex = text.indexOf('while')
+		if(whileIndex != -1) {
+			val openIndex = text.indexOf('(',whileIndex)
+			if(openIndex != -1) {
+				return openIndex;
+			}
+		}
+		 
+		 
+		/*
+		 * If case
+		 */
+		val ifIndex = text.indexOf('if')
+		if(ifIndex != -1) {
+			val openIndex = text.indexOf('(',ifIndex)
+			val thenIndex = text.indexOf('then',ifIndex)
+			if(openIndex != -1 && (thenIndex == -1 || openIndex < thenIndex)) { //check 'if' is not an 'if expression'
+				return openIndex
+			}
+		}
+		 
+		/*
+		 * Simple expression / default case
+		 */
+		return 0
+	}
+	
+	/**
+	 * Return the beginning of the expression before the offset
+	 */
+	private def String getOffsetPrefix(ContentAssistContext context) {
+		val stmtNode = findStatementNode(context.currentNode, context.offset-1)
+		if(stmtNode !== null) {
+			val stmtText = context.document.get(stmtNode.offset,stmtNode.length)
+			val startIndex = findStart(stmtText,context.offset-1-stmtNode.offset)
+			val startOffset = stmtNode.offset + startIndex
+			return context.document.get(startOffset,context.offset-startOffset)
+		}
+		return ""
+	}
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/TypeUtils.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/TypeUtils.xtend
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ui.contentassist
+
+import org.eclipse.emf.ecore.EClassifier
+import org.eclipse.emf.ecore.EStructuralFeature
+import org.eclipse.emf.ecoretools.ale.BoolType
+import org.eclipse.emf.ecoretools.ale.ClassifierType
+import org.eclipse.emf.ecoretools.ale.IntType
+import org.eclipse.emf.ecoretools.ale.RealType
+import org.eclipse.emf.ecoretools.ale.SeqType
+import org.eclipse.emf.ecoretools.ale.SetType
+import org.eclipse.emf.ecoretools.ale.StringType
+import org.eclipse.emf.ecoretools.ale.rType
+import org.eclipse.emf.ecoretools.ale.typeLiteral
+
+final class TypeUtils {
+	
+	private new() {
+		// this utility provide extension methods, it should not be instantiated
+	}
+	
+    def static String asString(rType type) {
+    	if (type instanceof ClassifierType) {
+    		return type.className
+    	}
+		if (type instanceof SetType) {
+			return "Set(" + type.type.asString + ")"
+		}
+		if (type instanceof SeqType) {
+			return "Sequence(" + type.type.asString + ")"
+		}
+		if (type instanceof StringType) {
+			return "EString"			
+		}
+		if (type instanceof BoolType) {
+			return "EBoolean"
+		}
+		if (type instanceof IntType) {
+			return "EInteger"
+		}
+		if (type instanceof RealType) {
+			return "EDouble"
+		}
+    	if (type instanceof typeLiteral) {
+	    	return type.eClass.name
+    	}
+    	return type.name
+    }
+    
+    def static String typeAsString(EStructuralFeature feature) {
+    	if (feature.isMany) {
+			if (feature.isUnique) {
+				return "Set(" + feature.EType.asString + ")"
+			}
+			else {
+				return "Sequence(" + feature.EType.asString + ")"
+			}
+    	}
+    	return feature.EType.asString
+    }
+    
+    def static String asString(EClassifier type) {
+    	return type.name
+    }
+	
+}


### PR DESCRIPTION
Because current autocompletion is not helpful (fix #92).

### Implementation

`AleProposalProvider` has been enhanced to dynamically retrieve `self`'s attributes from both the Ecore model and the ALE script.

A new `AleTemplateProposalProvider` has been created to dynamically retrieve `self`'s operations from both the Ecore model and the ALE script. These operations are autocompleted as [templates](https://www.eclipse.org/pdt/help/html/templates.htm). The reason why I chose to use templates for operations instead of bare proposals is because a template is defined by a pattern that can contain one or several placeholders; once the template is inserted in the editor these placeholders can easily be edited by the user. I rely on this feature to make easier for the user to set the parameters of an operation.

### Additional notes

With this PR, the editor will autocomplete `self`'s attributes and operations **only**. No other keyword is supported. I made this choice because the default autocomplete proposals were very bad and I believe it will now be easier to see when we expect autocomplete proposals and to implement them accordingly.

<div align="center">
<img src="https://user-images.githubusercontent.com/25926433/74235584-a9447a80-4ccf-11ea-92cc-4cc1dcd5edd0.png"/>
</div>
