### PR TITLE
[CI] Upgrade Xtend to 2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<tycho.version>1.2.0</tycho.version>
-		<xtend.version>2.14.0</xtend.version>
+		<xtend.version>2.19.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Recent releases of Eclipse IDE use Xtend 2.19 so let's upgrade the version used during Maven build. Otherwise we end up with code that compiles in the IDE but [not during Maven build](https://ci.inria.fr/gemoc/job/ale-lang/job/master/29/) (see commit 7fb08bf introduced by PR #97).

[The build passed successfully](https://ci.inria.fr/gemoc/job/ale-lang/job/upgrade-xtend-to-2.19/1/); do we have any reason to stay on Xtend 2.14?

At the time of writing:

| Xtend version | Release date | Comments |
 :--- | :--- | :---
2.20 | December 2019 | Latest release (likely used in Eclipse 2019-12)
2.19 | September 2019 | Used in Eclipse 2019-09
2.14 | May 2018 | Version currently used in our builds