### PR TITLE
[CI] Make Xtend code compliant with Xtend 2.14

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleProposalProvider.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleProposalProvider.xtend
@@ -90,14 +90,14 @@ class AleProposalProvider extends AbstractAleProposalProvider {
     
     override completeRuleCall(RuleCall object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
     	// Prevent Xtext from proposing unexpected proposals (such as '1')
-    	return
+    	return;
     }
 	
 	override completeExpression_Feature(EObject element, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		val prefix = getOffsetPrefix(context)
 		
 		if (prefix.startsWith("self.") || (element instanceof VarRef && ((element as VarRef).ID == "self"))) {
-			val typed = prefix.contains('.') ? prefix.substring(prefix.indexOf('.') + 1) : prefix
+			val typed = if (prefix.contains('.')) prefix.substring(prefix.indexOf('.') + 1) else prefix
 			var clazz = element.enclosingBehavioredClass
 			
 			// Autocomplete attributes declared within the ALE script
@@ -169,7 +169,7 @@ class AleProposalProvider extends AbstractAleProposalProvider {
 		}
 	}
 	
-	def getSemantics(EObject model, ContentAssistContext context) {
+	private def getSemantics(EObject model, ContentAssistContext context) {
 		/*
 		 * Metamodel input
 		 */

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleTemplateProposalProvider.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/contentassist/AleTemplateProposalProvider.xtend
@@ -91,7 +91,7 @@ class AleTemplateProposalProvider extends DefaultTemplateProposalProvider {
 			 * Autocomplete self.<typed>
 			 */
 			if (prefix.startsWith("self.") || (element instanceof VarRef && ((element as VarRef).ID == "self"))) {
-				val typed = prefix.contains('.') ? prefix.substring(prefix.indexOf('.') + 1) : prefix
+				val typed = if (prefix.contains('.')) prefix.substring(prefix.indexOf('.') + 1) else prefix
 				var clazz = element.enclosingBehavioredClass
 				
 				// Used to ensure that only one template is created for overridden operations (which are defined both in Ecore and ALE)
@@ -147,7 +147,7 @@ class AleTemplateProposalProvider extends DefaultTemplateProposalProvider {
 		}
 	}
 	
-	def getSemantics(EObject model, ContentAssistContext context) {
+	private def getSemantics(EObject model, ContentAssistContext context) {
 		/*
 		 * Metamodel input
 		 */


### PR DESCRIPTION
Because last commit 7fb08bf broke the CI due to Xtend 2.19 being used and we're not ready yet to migrate from 2.14 (see #99)