### PR TITLE
[Editor] Enhance dark theme

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/.classpath
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/.classpath
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/.project
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emf.ecoretools.ale.xtext.ide.theme</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: ALE Theme
+Bundle-SymbolicName: org.eclipse.emf.ecoretools.Ale;singleton:=true
+Bundle-Version: 1.1.0.qualifier
+Bundle-Vendor: Inria
+Automatic-Module-Name: org.eclipse.emf.ecoretools.Ale
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.e4.ui.css.swt;bundle-version="0.13.100",
+ org.eclipse.osgi
+Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/build.properties
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/build.properties
@@ -1,0 +1,6 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml,\
+               css/

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/css/dark-theme.css
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/css/dark-theme.css
@@ -1,0 +1,26 @@
+IEclipsePreferences#org-eclipse-emf-ecoretools-Ale:ecoretools-ale-ui-themes { /* pseudo attribute added to allow contributions without replacing this node, see Bug 466075 */
+	
+	preferences:
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Attribute access.color=102,225,248'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Attribute declaration.color=102,225,248'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Classes.color=18,144,195'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Method call.color=167,236,33'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Method definition.color=30,181,64'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Method parameter.color=242,242,0'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Open class definition.color=18,144,195'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Open class definition.style=0'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Self keyword.color=204,108,29'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Self keyword.style=2'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Tag.color=160,160,160'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Tag.style=2'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Local variable declaration.color=242,242,0'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Local variable reference.color=243,236,121'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Result variable.color=102,225,248'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.Result variable.style=2'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.comment.color=128,128,128'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.keyword.color=204,108,29'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.keyword.style=0'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.punctuation.color=230,230,250'
+		'org.eclipse.emf.ecoretools.Ale.syntaxColorer.tokenStyles.string.color=23,198,163'
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/plugin.xml
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ide.theme/plugin.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+	<extension
+       id="org.eclipse.emf.ecoretools.Ale.theme"
+       point="org.eclipse.e4.ui.css.swt.theme">
+    <stylesheet
+          uri="css/dark-theme.css">
+       <themeid
+             refid="org.eclipse.e4.ui.css.theme.e4_dark">
+       </themeid>
+    </stylesheet>
+	</extension>
+</plugin>

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleHighlightingConfiguration.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleHighlightingConfiguration.xtend
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2019-2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ui
+
+import org.eclipse.xtext.ui.editor.syntaxcoloring.DefaultHighlightingConfiguration
+import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfigurationAcceptor
+
+class AleHighlightingConfiguration extends DefaultHighlightingConfiguration {
+	
+	public static val String ATTRIBUTE_ACCESS_ID = "Attribute access"
+	public static val String ATTRIBUTE_DECLARATION_ID = "Attribute declaration"
+	public static val String CLASSES_ID = "Classes";
+	public static val String LOCAL_VARIABLE_DECLARATION_ID = "Local variable declaration"
+	public static val String LOCAL_VARIABLE_REFERENCE_ID = "Local variable reference"
+	public static val String METHOD_CALL_ID = "Method call";
+	public static val String METHOD_DEFINITION_ID = "Method definition"
+	public static val String METHOD_PARAMETER_ID = "Method parameter";
+	public static val String OPEN_CLASS_DEFINITION_ID = "Open class definition"
+	public static val String RESULT_VARIABLE_ID = "Result variable"
+	public static val String SELF_ID = "Self keyword";
+	public static val String SERVICE_IMPORT_ID = "Service import";
+	public static val String TAG_ID = "Tag"
+	
+	override configure(IHighlightingConfigurationAcceptor acceptor) {
+		acceptor.acceptDefaultHighlighting(ATTRIBUTE_ACCESS_ID, ATTRIBUTE_ACCESS_ID, attributeDeclarationStyle)
+		acceptor.acceptDefaultHighlighting(ATTRIBUTE_DECLARATION_ID, ATTRIBUTE_DECLARATION_ID, attributeAccessStyle)
+		acceptor.acceptDefaultHighlighting(CLASSES_ID, CLASSES_ID, classesStyle())
+		acceptor.acceptDefaultHighlighting(COMMENT_ID, "Comment", commentTextStyle)
+		acceptor.acceptDefaultHighlighting(DEFAULT_ID, "Default", defaultTextStyle)
+		acceptor.acceptDefaultHighlighting(KEYWORD_ID, "Keyword", keywordTextStyle)
+		acceptor.acceptDefaultHighlighting(LOCAL_VARIABLE_DECLARATION_ID, LOCAL_VARIABLE_DECLARATION_ID, localVariableStyle)
+		acceptor.acceptDefaultHighlighting(LOCAL_VARIABLE_REFERENCE_ID, LOCAL_VARIABLE_REFERENCE_ID, localVariableStyle)
+		acceptor.acceptDefaultHighlighting(METHOD_CALL_ID, METHOD_CALL_ID, methodCallStyle)
+		acceptor.acceptDefaultHighlighting(METHOD_DEFINITION_ID, METHOD_DEFINITION_ID, methodStyle())
+		acceptor.acceptDefaultHighlighting(METHOD_PARAMETER_ID, METHOD_PARAMETER_ID, methodParameterStyle())
+		acceptor.acceptDefaultHighlighting(NUMBER_ID, "Number", numberTextStyle)
+		acceptor.acceptDefaultHighlighting(OPEN_CLASS_DEFINITION_ID, OPEN_CLASS_DEFINITION_ID, openClassDefinitionStyle())
+		acceptor.acceptDefaultHighlighting(PUNCTUATION_ID, "Punctuation", punctuationTextStyle)
+		acceptor.acceptDefaultHighlighting(RESULT_VARIABLE_ID, RESULT_VARIABLE_ID, resultVariableStyle)
+		acceptor.acceptDefaultHighlighting(SELF_ID, SELF_ID, selfKeywordStyle)
+		acceptor.acceptDefaultHighlighting(SERVICE_IMPORT_ID, SERVICE_IMPORT_ID, serviceStyle())
+		acceptor.acceptDefaultHighlighting(STRING_ID, "String", stringTextStyle());
+		acceptor.acceptDefaultHighlighting(TAG_ID, TAG_ID, tagStyle)
+	}
+	
+	private def attributeDeclarationStyle() {
+		return defaultTextStyle
+	}
+	
+	private def attributeAccessStyle() {
+		return defaultTextStyle
+	}
+	
+	private def serviceStyle() {
+		return defaultTextStyle
+	}
+	
+	private def methodStyle() {
+		return defaultTextStyle
+	}
+	
+	private def classesStyle() {
+		return defaultTextStyle
+	}
+	
+	private def openClassDefinitionStyle() {
+		return defaultTextStyle
+	}
+	
+	private def localVariableStyle() {
+		return defaultTextStyle
+	}
+	
+	private def methodCallStyle() {
+		return defaultTextStyle
+	}
+	
+	private def methodParameterStyle() {
+		return defaultTextStyle
+	}
+	
+	private def resultVariableStyle() {
+		return defaultTextStyle
+	}
+	
+	private def selfKeywordStyle() {
+		return defaultTextStyle
+	}
+	
+	private def tagStyle() {
+		return defaultTextStyle
+	}
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleSemanticHighlightingCalculator.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleSemanticHighlightingCalculator.xtend
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ui
+
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.AbstractRule
+import org.eclipse.xtext.Action
+import org.eclipse.xtext.Assignment
+import org.eclipse.xtext.Keyword
+import org.eclipse.xtext.RuleCall
+import org.eclipse.xtext.TerminalRule
+import org.eclipse.xtext.TypeRef
+import org.eclipse.xtext.ide.editor.syntaxcoloring.IHighlightedPositionAcceptor
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.xtext.impl.ActionImpl
+import org.eclipse.xtext.nodemodel.INode
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.util.CancelIndicator
+
+class AleSemanticHighlightingCalculator implements ISemanticHighlightingCalculator {
+
+	override provideHighlightingFor(XtextResource resource, IHighlightedPositionAcceptor acceptor, CancelIndicator cancelIndicator) {
+		if (resource === null || resource.getParseResult() === null)
+			return;
+			
+		val INode root = resource.getParseResult().getRootNode();
+		for (INode node : root.getAsTreeIterable()) {
+			
+			if (node.grammarElement instanceof RuleCall) {
+				var RuleCall rc = node.grammarElement as RuleCall;
+                val EObject c = node.grammarElement.eContainer;
+                
+                // Tests whether the node represents the name of an element (class, method, parameter).
+                if(c instanceof Assignment && (c as Assignment).getFeature().equals("name")) {
+                    val INode p = node.getParent();
+                    if (p !== null && p.grammarElement instanceof RuleCall) {
+                        rc = p.grammarElement as RuleCall;
+                        val AbstractRule r2 = rc.getRule();
+			   
+                        // Tests whether the parent node represents a method.                        
+                        if (r2.name == "rOperation") {
+                            acceptor.addPosition(node.getOffset(), node.getLength(), AleHighlightingConfiguration.METHOD_DEFINITION_ID);
+                        }
+                        else if (r2.name == "rTag") {
+                            acceptor.addPosition(node.getOffset() - 1, node.getLength() + 1, AleHighlightingConfiguration.TAG_ID);
+                        }
+                        else if (r2.name == "rType") {
+                            acceptor.addPosition(node.getOffset(), node.getLength(), AleHighlightingConfiguration.CLASSES_ID);
+                        }
+                        else if (r2.name == "rOpenClass") {
+                            acceptor.addPosition(node.getOffset(), node.getLength(), AleHighlightingConfiguration.OPEN_CLASS_DEFINITION_ID);
+                        }
+                        else if (r2.name == "rVariable") {
+                            acceptor.addPosition(node.getOffset(), node.getLength(), AleHighlightingConfiguration.METHOD_PARAMETER_ID);
+                        }
+                        else if (r2.name == "rService") {
+                            acceptor.addPosition(node.getOffset(), node.getLength(), AleHighlightingConfiguration.SERVICE_IMPORT_ID);
+                        }
+                        else if (r2.name == "rAttribute") {
+                        	acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.ATTRIBUTE_DECLARATION_ID);
+                        }
+                        else if (r2.name == "rVarDecl") {
+                        	acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.LOCAL_VARIABLE_DECLARATION_ID)
+                        }
+                    }
+                }
+				// Tests whether the node represents an iterator            
+                if(c instanceof Assignment && (c as Assignment).getFeature().equals("iterator")) {
+                	val INode p = node.getParent();
+                    if (p !== null && p.grammarElement instanceof RuleCall) {
+                        rc = p.grammarElement as RuleCall;
+                        val AbstractRule r2 = rc.getRule();
+			   
+                        // Matches for-each loops' iterator (e.g. for(<iterator> in <collection>)                     
+                        if (r2.name == "rForEach") {
+                            acceptor.addPosition(node.getOffset(), node.getLength(), AleHighlightingConfiguration.LOCAL_VARIABLE_DECLARATION_ID);
+                        }
+                    }
+                }
+			}
+			else if (node.grammarElement instanceof Keyword) {
+				val keywords = 
+					#{"open", "class", "def", "open", "use", "behavior", "true", "false", 
+					  "and", "or", "implies", "unique", "contains", "opposite", "override",
+					  "import", "as", "for", "if", "while", "switch", "default", "xor", "not",
+					  "then", "else", "endif", "in", "let", "null", "case"}
+				
+				// FIXME [Refactor] Those shouldn't be keywords; looks like a hack that should be fixed
+				val misc = #{"String", "Integer", "Real", "Boolean", "Sequence", "OrderedSet"}
+				
+				if (keywords.contains(node.text)) {
+					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.KEYWORD_ID)
+				}
+				else if (! misc.contains(node.text)) {
+					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.PUNCTUATION_ID)
+				}
+			}
+			else if (node.grammarElement instanceof TerminalRule) {
+				val rule = node.grammarElement as TerminalRule
+				if (rule.name == "SL_COMMENT") {
+					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.COMMENT_ID)
+				}				
+				else if (rule.name == "ML_COMMENT") {				
+					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.COMMENT_ID)
+				}				
+				else if (rule.name == "WS") {
+					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.DEFAULT_ID)
+				}
+				else {
+					print("rule: " + rule.name)
+					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.DEFAULT_ID)
+				}
+			}
+			else if (node.grammarElement instanceof Action) {
+				val action = node.grammarElement as Action
+				
+				if (action.type instanceof TypeRef) {
+					if (action.type.classifier.name == "Lit") {
+						// Seems to be handled anyway
+//						acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.STRING_ID)
+					}
+					else if (action.type.classifier.name.endsWith("Type")) {
+						acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.CLASSES_ID)
+					}
+					else if (action.type.classifier.name == "Int") {
+						acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.NUMBER_ID)
+					}
+					else if (action.type.classifier.name == "String") {
+						acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.STRING_ID)
+					}
+					else if (action.type.classifier.name == "Block") {
+						acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.DEFAULT_ID)
+					}
+					else if (action.type.classifier.name == "True" || action.type.classifier.name == "False") {
+						// already handled by the Keyword rule
+					}
+					else if (action.type.classifier.name == "Call") {
+						val text = node.text.trim
+						var offset = node.offset
+						var length = node.length
+						
+						if (text.contains(".")) {
+							offset += text.indexOf('.')
+							length -= text.indexOf('.')
+						}
+						acceptor.addPosition(offset, length, AleHighlightingConfiguration.METHOD_CALL_ID)
+					}
+					else if (action.type.classifier.name == "VarRef") {
+						val variable = node.text.trim
+						
+						if (variable == "self") {
+							acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.SELF_ID)
+						}
+						else if (variable == "result") {
+							acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.RESULT_VARIABLE_ID)
+						}
+						else {
+							acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.LOCAL_VARIABLE_REFERENCE_ID)
+						}
+					}
+					else if (action.type.classifier.name == "Add") {
+						// an addition or a subtraction, no specific style
+					}
+					else if (action.type.classifier.name == "Feature") {
+						val dotIndex = node.text.trim.indexOf('.')
+						if (dotIndex > 0) {
+							acceptor.addPosition(node.offset + dotIndex + 1, node.length - dotIndex - 1, AleHighlightingConfiguration.ATTRIBUTE_ACCESS_ID)
+						}
+					}
+					else if (action.type.classifier.name == "OrderedSet" || action.type.classifier.name == "Sequence") {
+						// constructor call
+						acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.METHOD_CALL_ID)
+					}
+					else {
+						// at least operators like '>' and '<'
+					}
+				}
+				else {
+					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.SERVICE_IMPORT_ID)
+				}
+			}
+			else {
+				acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.DEFAULT_ID)
+			}
+		}
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleUiModule.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleUiModule.xtend
@@ -3,8 +3,10 @@
  */
 package org.eclipse.emf.ecoretools.ui
 
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.emf.ecoretools.ui.contentassist.AleTemplateProposalProvider
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration
 
 /**
  * Use this class to register components to be used within the Eclipse IDE.
@@ -14,6 +16,14 @@ class AleUiModule extends AbstractAleUiModule {
 	
 	override bindITemplateProposalProvider() {
 		return typeof(AleTemplateProposalProvider)
+	}
+	
+	def Class<? extends IHighlightingConfiguration> bindIHighlightingConfiguration() {
+		return typeof(AleHighlightingConfiguration);
+	}
+	
+	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
+		return typeof(AleSemanticHighlightingCalculator);
 	}
 	
 }


### PR DESCRIPTION
## Contribution

Closes #93, closes #94.

Beautifies ALE's editor in dark theme:

<div align="center">
<img alt="screenshot of ALE's editor in dark theme" src="https://user-images.githubusercontent.com/25926433/75280003-edc23100-580c-11ea-9ab6-82b63840e8ca.png"/>
</div>

The dark theme is similar to JDT's one. I tested on both Eclipse Photon (ALE's current target platform) and 2019-12 (latest release at the time of writing).

## Implementation

 - the new 'org.eclipse.emf.ecoretools.ale.xtext.ide.theme' bundle provides the colors to use in dark theme as CSS
 - new classes have been created in the xtext.ui bundle to identify the tokens semantically so that they can be colored properly

## Additional notes

 - the symbolic name of the `xtext.ide.theme` bundle is currently `org.eclipse.emf.ecoretools.Ale`. This is because we need a bundle named after Xtext language so that Eclipse's CSS Engine properly override color preferences when switching to dark theme in Photon
 - see [this thread](https://www.eclipse.org/forums/index.php?t=msg&th=1101764&goto=1821997&#msg_1821997) [1] for the details

 [1] https://www.eclipse.org/forums/index.php?t=msg&th=1101764&goto=1821997&#msg_1821997