### PR TITLE
[Type Checker] Allow use of methods to define for-each loops' range

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleSemanticHighlightingCalculator.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleSemanticHighlightingCalculator.xtend
@@ -115,7 +115,6 @@ class AleSemanticHighlightingCalculator implements ISemanticHighlightingCalculat
 					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.DEFAULT_ID)
 				}
 				else {
-					print("rule: " + rule.name)
 					acceptor.addPosition(node.offset, node.length, AleHighlightingConfiguration.DEFAULT_ID)
 				}
 			}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/forEachRangeFromMethodCall.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/forEachRangeFromMethodCall.implem
@@ -1,0 +1,13 @@
+behavior test.foreach;
+open class EClass {
+
+	def void main() {
+		for (city in self.cities()) {
+			city.log();
+		}
+	}
+	
+	def Sequence(String) cities() {
+		result := Sequence{'Paris', 'London'};
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -1213,6 +1213,22 @@ public class TypeValidatorTest {
 	}
 	
 	/*
+	 * Test that a method can be used to set the range of a for-each loop
+	 */
+	@Test
+	public void testForEachRangeFromMethodCall() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/forEachRangeFromMethodCall.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals("Got: " + msg, 0, msg.size());
+	}
+	
+	/*
 	 * Test If expression is a boolean
 	 */
 	@Test


### PR DESCRIPTION
Closes #102

Correctly type checks:

```ale
def void main() {
    for (city in self.cities()) {
        city.log();
    }
}
	
def Sequence(String) cities() {
    result := Sequence{'Paris', 'London'};
}