### PR TITLE
Allow to assign null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Fixed
+- [#64](https://github.com/gemoc/ale-lang/issues/64) Allow to assign `null` to variables
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
 
 ### Added

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
@@ -203,6 +203,16 @@ public interface ITypeChecker {
 	boolean isInteger(IType type);
 
 	/**
+	 * Determines whether the given type corresponds to {@code null}.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type represents {@code null}
+	 */
+	boolean isNull(IType type);
+	
+	/**
 	 * Determines whether the given type corresponds to a string.
 	 * 
 	 * @param type

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidationMessageFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidationMessageFactory.java
@@ -125,18 +125,6 @@ public interface IValidationMessageFactory {
 	/**
 	 * Creates a message warning about unexpected types.
 	 * 
-	 * @param att
-	 * 			The attribute having the expected types
-	 * @param actualTypes
-	 * 			The actual, unexpected types
-	 * 
-	 * @return a new validation message
-	 */
-	IValidationMessage incompatibleTypes(Attribute att, Set<IType> actualTypes);
-	
-	/**
-	 * Creates a message warning about unexpected types.
-	 * 
 	 * @param expected
 	 * 			The expected types
 	 * @param actual

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -28,6 +28,7 @@ import org.eclipse.acceleo.query.validation.type.EClassifierType;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecoretools.ale.core.validation.impl.AstLookup;
@@ -159,10 +160,7 @@ public class TypeValidator implements IValidator {
 		.forEach(att -> {
 			Set<IType> valueTypes = lookup.inferredTypesOf(att.getInitialValue());
 			IType declaredType = convert.toAQL(att.getFeatureRef());
-			boolean initialValueCanBeAssigned = valueTypes.stream().anyMatch(declaredType::isAssignableFrom);
-			if(!initialValueCanBeAssigned){
-				msgs.add(messages.incompatibleTypes(att, valueTypes));
-			}
+			msgs.addAll(validateAssignment(newHashSet(declaredType), valueTypes, att.getInitialValue()));
 		});
 		return msgs;
 	}
@@ -253,7 +251,7 @@ public class TypeValidator implements IValidator {
 	 * 
 	 * @return the messages produced by the validation of the assignment
 	 */
-	private List<IValidationMessage> validateAssignment(Set<IType> variableTypes, Set<IType> valueTypes, Expression valueExp) {
+	private List<IValidationMessage> validateAssignment(Set<IType> variableTypes, Set<IType> valueTypes, EObject valueExp) {
 		if(variableTypes.isEmpty()) {
 			// The variable has no type: it is likely undeclared
 			return PROBLEM_HANDLED_BY_ANOTHER_VALIDATOR;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
@@ -148,6 +148,9 @@ public final class TypeChecker implements ITypeChecker {
 		//
 		// It could also worth considering adding EObject as a super type of user's classes to help IType doing its
 		// job well. This could be done in DslBuilder#register(List<EPackages>).
+		if (isNull(valueType)) {
+			return true;
+		}
 		boolean bothAreCollections = isCollection(variableType) && isCollection(valueType);
 		if(bothAreCollections) {
 			return collectionsHaveCompatibleGenericTypes(variableType, valueType);
@@ -217,6 +220,17 @@ public final class TypeChecker implements ITypeChecker {
 			EDataType dataType = (EDataType) type.getType();
 			return int.class.equals(dataType.getInstanceClass())
 				|| Integer.class.equals(dataType.getInstanceClass());
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean isNull(IType type) {
+		if (type.getType() == null) {
+			return true;
+		}
+		if (type instanceof NothingType) {
+			return true;
 		}
 		return false;
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ValidationMessageFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ValidationMessageFactory.java
@@ -22,11 +22,9 @@ import org.eclipse.acceleo.query.runtime.ValidationMessageLevel;
 import org.eclipse.acceleo.query.runtime.impl.ValidationMessage;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
 import org.eclipse.emf.ecoretools.ale.core.validation.IValidationMessageFactory;
-import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
 import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
 import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
@@ -39,7 +37,6 @@ public final class ValidationMessageFactory implements IValidationMessageFactory
 	public static final String ILLEGAL_ASSIGNMENT = "Type mismatch: cannot assign %s to %s";
 	public static final String ILLEGAL_INSERTION = "%s cannot be added to %s (expected %s)";
 	public static final String ILLEGAL_REMOVAL = "%s cannot be removed from %s (expected %s)";
-	public static final String INCOMPATIBLE_TYPE = "Expected %s but was %s";
 	public static final String INCOMPATIBLE_TYPES = "Expected %s but was %s";
 	public static final String INDIRECT_EXTENSION = "Can't extend %s since it is not a direct super type of %s";
 	public static final String UNSUPPORTED_OPERATOR = "%s does not support the '%s' operator";
@@ -121,17 +118,6 @@ public final class ValidationMessageFactory implements IValidationMessageFactory
 				String.format(ILLEGAL_REMOVAL, commaSeparated(removedValueTypes), commaSeparated(variableTypes), commaSeparated(acceptedValueTypes)),
 				base.getStartOffset(value),
 				base.getEndOffset(value) + 1
-		);
-	}
-	
-	@Override
-	public IValidationMessage incompatibleTypes(Attribute att, Set<IType> actualTypes) {
-		EClassifier expectedType = att.getFeatureRef().getEType();
-		return new ValidationMessage(
-				ValidationMessageLevel.ERROR,
-				String.format(INCOMPATIBLE_TYPE, getQualifiedName(expectedType), commaSeparated(actualTypes)),
-				base.getStartOffset(att),
-				base.getEndOffset(att)
 		);
 	}
 	

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignNullToAttribute.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignNullToAttribute.implem
@@ -1,0 +1,19 @@
+behavior test.declself;
+
+open class EClass {
+	int intAttribute;
+	String stringAttribute;
+	EObject classAttribute;
+	declself::Foo runtimeClassAttribute;
+	
+	def void foo() {
+		self.intAttribute := null;
+		self.stringAttribute := null;
+		self.classAttribute := null;
+		self.runtimeClassAttribute := null;
+	}
+}
+
+class Foo {
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignNullToLocalVariables.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignNullToLocalVariables.implem
@@ -1,0 +1,15 @@
+behavior test.declself;
+
+open class EClass {
+	
+	def void foo() {
+		int intAttribute := null;
+		String stringAttribute := null;
+		EObject classAttribute := null;
+		declself::Foo runtimeClassAttribute := null;
+	}
+}
+
+class Foo {
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/initializeAttributesToNull.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/initializeAttributesToNull.implem
@@ -1,0 +1,12 @@
+behavior test.declself;
+
+open class EClass {
+	int intAttribute := null;
+	String stringAttribute := null;
+	EObject classAttribute := null;
+	declself::Foo runtimeClassAttribute := null;
+}
+
+class Foo {
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
@@ -898,9 +898,8 @@ public class NameValidatorTest {
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
-		assertEquals(2, msg.size());
+		assertEquals("messages: " + msg, 1, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 112, 117, "Feature wrong not found in EClass EClass", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 108, 118, "Type mismatch: cannot assign [Nothing(Feature wrong not found in EClass EClass)] to [ecore::EInt]", msg.get(1));
 	}
 	
 	/*

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -186,7 +186,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 45, 62, "Expected ecore::EString but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 61, 62, "Type mismatch: cannot assign [java.lang.Integer] to [ecore::EString]", msg.get(0));
 	}
 	
 	/*
@@ -1718,6 +1718,45 @@ public class TypeValidatorTest {
 		
 		assertEquals(1, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 110, 132, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
+	}
+	
+	@Test
+	public void testInitAttributesToNull() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/initializeAttributesToNull.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals("Unexpected errors: " + msg, 0, msg.size());
+	}
+	
+	@Test
+	public void testAssignNullToAttribute() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/assignNullToAttribute.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals("Unexpected errors: " + msg, 0, msg.size());
+	}
+	
+	@Test
+	public void testAssignNullToLocalVariables() {
+		Dsl environment = new Dsl(Arrays.asList(),Arrays.asList("input/validation/assignNullToLocalVariables.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals("Unexpected errors: " + msg, 0, msg.size());
 	}
 	
 	/**


### PR DESCRIPTION
Close #64.

EDIT: allows to assign `null` to *any variable*. At first I wanted to prevent `null` assignment for primitives (numbers, booleans and even strings) but I believe that may have arm compatibility with Java services that may return `null` instead of a Boolean, an Integer or a String.

## Changes
 - the code has been slightly simplified: `TypeValidator` now valides attribute initializations in the same way it validates other assignments
 - as a result, when assigning an illegal value to an attribute the editor now underlines the illegal value only instead of the whole expression