### PR TITLE
Improve ALE console with a clean, colored stacktrace with hyperlink

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/META-INF/MANIFEST.MF
@@ -25,5 +25,6 @@ Require-Bundle: org.antlr.runtime;bundle-version="[4.3.0,4.4.0)",
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.acceleo.query;visibility:=reexport,
- com.google.guava;bundle-version="11.0.0"
+ com.google.guava;bundle-version="11.0.0",
+ org.eclipse.core.resources
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DiagnosticLogger.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DiagnosticLogger.java
@@ -11,12 +11,17 @@
 package org.eclipse.emf.ecoretools.ale.core.interpreter;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.regex.Pattern.MULTILINE;
 
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.eclipse.acceleo.query.ast.Expression;
 import org.eclipse.emf.common.util.BasicDiagnostic;
@@ -26,6 +31,12 @@ import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult;
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 
 public class DiagnosticLogger {
+	
+	/**
+	 * Matches AQL's error messages and returned the actual, wrapped error.
+	 */
+	private static final Pattern AQL_SERVICE_ERROR_PATTERN = Pattern.compile(".*with arguments \\[.*\\].* failed:(.*)", Pattern.DOTALL);
+	
 	List<Diagnostic> log = new ArrayList<>();
 	private final DslSemantics semantics;
 	
@@ -54,10 +65,10 @@ public class DiagnosticLogger {
 	public void diagnosticForHuman( BasicDiagnostic diagnostic) {
 		diagnostic
 			.getChildren()
-			.stream()
 			.forEach(
 				diag -> {
-					if(diag.getSource().equals(MethodEvaluator.PLUGIN_ID)){
+					// We only want to display our own errors
+					if (diag.getSource().equals(MethodEvaluator.PLUGIN_ID)) {
 						Expression failedExp = (Expression) diag.getData().get(0);
 						Diagnostic diagExp = diag;
 						
@@ -65,30 +76,41 @@ public class DiagnosticLogger {
 						if(diag.getData().size() > 1) {
 							diagExp = (Diagnostic) diag.getData().get(1);
 						}
-						printError(failedExp, diagExp.toString());
+						printError(failedExp, diagExp);
 						if(diagExp instanceof BasicDiagnostic) {
 							diagnosticForHuman((BasicDiagnostic) diagExp);
 						}
-					} else {
-						if(!diag.getData().isEmpty() && diag.getData().get(0) instanceof Exception) {
-							Exception e = (Exception) diag.getData().get(0);
-							if(e.getCause() instanceof CriticalFailure) {
-								CriticalFailure interpreterFailure = (CriticalFailure) e.getCause();
-								diagnosticForHuman(interpreterFailure.diagnostics);
-							} else if(e.getCause() != null){
-								e.getCause().printStackTrace();
-							}
-						}
 					}
+					
+					// TODO Consider removing the code below
+					//		I comment it because it exposes internal and irrelevant errors
+					//		to the user. However, it may be useful for debugging purposes
+					//		and I prefer to comment it out: it will be easier to find it.
+					
+//					else {
+//						if(!diag.getData().isEmpty() && diag.getData().get(0) instanceof Exception) {
+//							Exception e = (Exception) diag.getData().get(0);
+//							if(e.getCause() instanceof CriticalFailure) {
+//								CriticalFailure interpreterFailure = (CriticalFailure) e.getCause();
+//								diagnosticForHuman(interpreterFailure.diagnostics);
+//							} else if(e.getCause() != null){
+//								e.getCause().printStackTrace();
+//							}
+//						}
+//					}
 				}
 			);
 	}
 	
-	private void printError(Expression expr, String errorMsg) {
+	private void printError(Expression expr, Diagnostic diagnostic) {
 		ParseResult<ModelUnit> parsedFile = semantics.findParsedFileDefining(expr).orElse(null);
 		if (parsedFile == null) {
-			System.err.println("\n[AQL eval fail] At unknown file and line (" + expr + ")");
-			System.err.println(errorMsg);
+			System.err.println("\nAt unknown file and line (" + expr + "):\n");
+			Stream.concat(Stream.of(diagnostic), diagnostic.getChildren().stream())
+				  .map(Diagnostic::getMessage)
+				  .map(getActualError())
+				  .filter(msg -> msg != null && !msg.trim().isEmpty())
+				  .forEach(message -> System.err.println("    " + message));
 		}
 		else {
 			// TODO [Refactor] Optional<Integer> start = parsedFile.getStartPositionOf(expr)
@@ -96,9 +118,33 @@ public class DiagnosticLogger {
 			if(startPos != null) {
 				String file = parsedFile.getSourceFile();
 				int line =  getLine(startPos,file);
-				System.err.println("\n[AQL eval fail] At line "+ line +" in " + file + ":\n" + errorMsg);
+				System.err.println("\nAt line "+ line +" in " + file + ":");
+				Stream.concat(Stream.of(diagnostic), diagnostic.getChildren().stream())
+					  .map(Diagnostic::getMessage)
+					  .filter(msg -> msg != null && !msg.trim().isEmpty())
+					  .map(getActualError())
+					  .forEach(message -> System.err.println("    " + message));
 			}
 		}
+	}
+	
+	/**
+	 * Returns the wrapped error message or the message itself if it's not wrapped.
+	 * <p>
+	 * Required because AQL catch exceptions thrown by services and directly modifies
+	 * their (so, our) error message. 
+	 */
+	private Function<String, String> getActualError() {
+		return message -> {
+			Matcher matcher = AQL_SERVICE_ERROR_PATTERN.matcher(message);
+			
+			if (matcher.matches()) {
+				return matcher.group(1).trim();
+			}
+			else {
+				return message;
+			}
+		};
 	}
 	
 	private int getLine(int offset, String file) {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -57,6 +57,7 @@ import org.eclipse.emf.ecoretools.ale.implementation.While;
  */
 public class MethodEvaluator {
 	
+	public static final String ROOT_ERROR_MESSAGE = "AQL evaluation failed";
 	public static final String PLUGIN_ID = "interpreter"; //FIXME: set real name
 	public static final String AQL_ERROR = "An error occured during evaluation of a query";
 	public static final String MTD_ERROR = "Can't eval null method on %s";
@@ -425,7 +426,7 @@ public class MethodEvaluator {
 					new Object[] { expression , result.getDiagnostic()}
 					);
 			diagnostic.add(child);
-			stopExecution("AQL evaluation failed");
+			stopExecution(ROOT_ERROR_MESSAGE);
 		}
 		
 		return result.getResult();

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: org.eclipse.emf.ecoretools.ale.ide,
  org.eclipse.jdt.core;resolution:=optional,
  org.eclipse.jdt.launching;resolution:=optional,
  org.eclipse.sirius.ext.base,
- org.eclipse.sirius.ui
+ org.eclipse.sirius.ui,
+ org.eclipse.core.filesystem
 Bundle-Vendor: Inria/Obeo
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.emf.ecoretools.ale.ide.ui

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/plugin.xml
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/plugin.xml
@@ -156,4 +156,13 @@
               name="ALE">
         </category>
      </extension>
+     <extension
+           point="org.eclipse.ui.console.consolePatternMatchListeners">
+        <consolePatternMatchListener
+              class="org.eclipse.emf.ecoretools.ale.ide.ui.io.HyperlinkAleConsoleMatcherListener"
+              id="org.eclipse.emf.ecoretools.ale.ide.ui.io.hyperlinkAleConsoleMatcherListener"
+              regex="At (.+):(.+)">
+           <enablement></enablement>
+        </consolePatternMatchListener>
+     </extension>
 </plugin>

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/io/AleConsole.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/io/AleConsole.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.ide.ui.io;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.MessageConsole;
+
+/**
+ * A console used to print the output of ALE programs.
+ */
+public class AleConsole extends MessageConsole {
+	
+	/**
+	 * Creates a new console aimed at printing the output of ALE programs.
+	 * 
+	 * @param name
+	 * 			The name of the console.
+	 * @param imageDescriptor
+	 * 			console image descriptor or null.
+	 */
+	private AleConsole(String name, ImageDescriptor imageDescriptor) {
+		super(name, imageDescriptor);
+	}
+	
+	/**
+	 * Returns the current ALE console.
+	 * <p>
+	 * If an ALE console is already open, returns this instance. If no ALE console is found, creates a new one.
+	 * 
+	 * @return the current ALE console
+	 */
+	public static AleConsole current() {
+		IConsole[] consoles = ConsolePlugin.getDefault().getConsoleManager().getConsoles();
+		
+		for (IConsole console : consoles) {
+			if (console instanceof AleConsole) {
+				return (AleConsole) console;
+			}
+		}
+		AleConsole console = new AleConsole("ALE Console", null);
+		ConsolePlugin.getDefault().getConsoleManager().addConsoles(new IConsole[] { console });
+		
+		return console;
+	}
+	
+	@Override
+	public void setName(String newName) {
+		super.setName(newName);
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/io/HyperlinkAleConsoleMatcherListener.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/io/HyperlinkAleConsoleMatcherListener.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.ide.ui.io;
+
+import static java.lang.Integer.parseInt;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.ecoretools.ale.ide.ui.Activator;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.console.IHyperlink;
+import org.eclipse.ui.console.IPatternMatchListenerDelegate;
+import org.eclipse.ui.console.PatternMatchEvent;
+import org.eclipse.ui.console.TextConsole;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+/**
+ * Turns stacktraces into hyperlinks within ALE consoles. 
+ */
+public class HyperlinkAleConsoleMatcherListener implements IPatternMatchListenerDelegate {
+
+	private TextConsole console;
+
+	@Override
+	public void connect(TextConsole console) {
+		if (console instanceof AleConsole) {
+			this.console = console;
+		}
+	}
+
+	@Override
+	public void disconnect() {
+		this.console = null;
+	}
+
+	@Override
+	public void matchFound(PatternMatchEvent event) {
+		if (!isInAleConsole()) {
+			return;
+		}
+		try {
+			String fileReferenceText = console.getDocument().get(event.getOffset(), event.getLength());
+			int filePathIndex = fileReferenceText.indexOf("At ") + "At ".length();
+			int separatorIndex = fileReferenceText.lastIndexOf(':');
+
+			String absoluteFilePath = fileReferenceText.substring(filePathIndex, separatorIndex);
+			int lineNumber = parseInt(fileReferenceText.substring(separatorIndex + 1));
+
+			IHyperlink hyperlink = makeHyperlink(absoluteFilePath, lineNumber); // a link to any file
+			console.addHyperlink(hyperlink, event.getOffset() + filePathIndex, event.getLength() - filePathIndex);
+		}
+		catch (Exception exception) {
+			Activator.error("Unable to create hyperlink from " + event.getOffset() + " to " + event.getLength(), exception);
+		}
+	}
+	
+	private boolean isInAleConsole() {
+		return console != null;
+	}
+
+	private static IHyperlink makeHyperlink(String absoluteFilePath, int lineNumber)
+	{
+		return new AleConsoleHyperlink(absoluteFilePath, lineNumber);
+	}
+	
+	/**
+	 * An hyperlink that opens the file in an editor when clicked. 
+	 */
+	private static final class AleConsoleHyperlink implements IHyperlink {
+		
+		private final String absoluteFilePath;
+		private final int lineNumber;
+
+		private AleConsoleHyperlink(String absoluteFilePath, int lineNumber) {
+			this.absoluteFilePath = absoluteFilePath;
+			this.lineNumber       = lineNumber;
+		}
+
+		@Override
+		public void linkExited() {
+			// nothing to do
+		}
+
+		@Override
+		public void linkEntered() {
+			// nothing to do
+		}
+
+		@Override
+		public void linkActivated() {
+			IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+			try {
+				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(absoluteFilePath));
+				IEditorPart editorPart = IDE.openEditor(page, file);
+				goToLine(editorPart, lineNumber);
+			}
+			catch (Exception exception) {
+				Activator.error("Unable to open an editor when hyperlinked to " + absoluteFilePath + ":" + lineNumber + " has been triggered", exception);
+			}
+		}
+
+		private static void goToLine(IEditorPart editorPart, int lineNumber) {
+			if (editorPart instanceof ITextEditor) {
+				ITextEditor textEditor = (ITextEditor) editorPart;
+				IDocument document = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
+				
+				if (document != null) {
+					IRegion region = null;
+
+					try {
+						region = document.getLineInformation(lineNumber - 1);
+						textEditor.selectAndReveal(region.getOffset(), region.getLength());
+					}
+					catch (BadLocationException exception) {
+						Activator.error("Unable to go to line " + lineNumber + " in editor " + editorPart, exception);
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/AleEvaluationJob.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/launchconfig/AleEvaluationJob.java
@@ -151,11 +151,9 @@ public class AleEvaluationJob extends Job {
 						interpreter.getLogger().diagnosticForHuman();
 
 						Diagnostic diagnostic = result.getDiagnostic();
-						if (diagnostic.getMessage() != null) {
-							System.err.println(diagnostic.getMessage());
-						}
 						LocalTime endTime = LocalTime.now();
 						String status = diagnostic.getSeverity() == Diagnostic.OK ? "<terminated> " : "<failed> ";
+						
 						updateConsoleName(console, status, caller, main, startTime, endTime);
 					} 
 					catch (ClosedALEInterpreterException e) {


### PR DESCRIPTION
Close #110.

## Changes

- the title of the console changes as the execution progresses
- error messages are shorter and printed in a red font
- stacktraces are cleaner and provide hyperlinks to source code

## Example

Given the following code (`self.piou` does not exist):

```kotlin
behavior piou;

open class Piou {
	
    @main
    def void main() {
        self.foo();
    }
	
    def void foo() {
        self.piou.foo();		
    }
}
```

The console was printing the following message:

<details>

  <summary><i>Click to expand</i></summary>

```kotlin
aqlFeatureAccess(org.eclipse.emf.ecore.EObject,java.lang.String) with arguments [org.eclipse.emf.ecore.impl.DynamicEObjectImpl@5c48f04e (eClass: org.eclipse.emf.ecore.impl.EClassImpl@2e83f3f5 (name: Piou) (instanceClassName: null) (abstract: false, interface: false)), piou] failed:
	Feature piou not found in EClass Piou

[AQL eval fail] At line 8 in C:\Users\echebbi\runtime-New_configuration(4)\piou\src-ale\piou.ale:
Diagnostic ERROR source=null code=0 null [Diagnostic ERROR source=org.eclipse.acceleo.query code=0 foo(Object=EClassifier=Piou) with arguments [org.eclipse.emf.ecore.impl.DynamicEObjectImpl@5c48f04e (eClass: org.eclipse.emf.ecore.impl.EClassImpl@2e83f3f5 (name: Piou) (instanceClassName: null) (abstract: false, interface: false))] failed:
	AQL evaluation failed data=[org.eclipse.acceleo.query.runtime.AcceleoQueryEvaluationException: foo(Object=EClassifier=Piou) with arguments [org.eclipse.emf.ecore.impl.DynamicEObjectImpl@5c48f04e (eClass: org.eclipse.emf.ecore.impl.EClassImpl@2e83f3f5 (name: Piou) (instanceClassName: null) (abstract: false, interface: false))] failed:
	AQL evaluation failed]]

[AQL eval fail] At line 12 in C:\Users\echebbi\runtime-New_configuration(4)\piou\src-ale\piou.ale:
Diagnostic WARNING source=null code=0 null [Diagnostic WARNING source=org.eclipse.acceleo.query code=0 aqlFeatureAccess(org.eclipse.emf.ecore.EObject,java.lang.String) with arguments [org.eclipse.emf.ecore.impl.DynamicEObjectImpl@5c48f04e (eClass: org.eclipse.emf.ecore.impl.EClassImpl@2e83f3f5 (name: Piou) (instanceClassName: null) (abstract: false, interface: false)), piou] failed:
	Feature piou not found in EClass Piou data=[org.eclipse.acceleo.query.runtime.AcceleoQueryEvaluationException: aqlFeatureAccess(org.eclipse.emf.ecore.EObject,java.lang.String) with arguments [org.eclipse.emf.ecore.impl.DynamicEObjectImpl@5c48f04e (eClass: org.eclipse.emf.ecore.impl.EClassImpl@2e83f3f5 (name: Piou) (instanceClassName: null) (abstract: false, interface: false)), piou] failed:
	Feature piou not found in EClass Piou]]
org.eclipse.acceleo.query.runtime.AcceleoQueryEvaluationException: Feature piou not found in EClass Piou
	at org.eclipse.emf.ecoretools.ale.core.interpreter.DynamicFeatureRegistry.getDynamicFeatureValue(DynamicFeatureRegistry.java:109)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.DynamicFeatureRegistry.aqlFeatureAccess(DynamicFeatureRegistry.java:86)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.services.DynamicEObjectServices.aqlFeatureAccess(DynamicEObjectServices.java:53)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at org.eclipse.acceleo.query.runtime.impl.JavaMethodService.internalInvoke(JavaMethodService.java:162)
	at org.eclipse.acceleo.query.runtime.impl.AbstractService.invoke(AbstractService.java:135)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.services.NotifyingEvaluationServices.callService(NotifyingEvaluationServices.java:83)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.services.NotifyingEvaluationServices.call(NotifyingEvaluationServices.java:66)
	at org.eclipse.acceleo.query.runtime.impl.EvaluationServices.callOrApply(EvaluationServices.java:208)
	at org.eclipse.acceleo.query.parser.AstEvaluator.caseCall(AstEvaluator.java:189)
	at org.eclipse.acceleo.query.ast.util.AstSwitch.doSwitch(AstSwitch.java:119)
	at org.eclipse.emf.ecore.util.Switch.doSwitch(Switch.java:53)
	at org.eclipse.emf.ecore.util.Switch.doSwitch(Switch.java:69)
	at org.eclipse.acceleo.query.parser.AstEvaluator.caseCall(AstEvaluator.java:180)
	at org.eclipse.acceleo.query.ast.util.AstSwitch.doSwitch(AstSwitch.java:119)
	at org.eclipse.emf.ecore.util.Switch.doSwitch(Switch.java:53)
	at org.eclipse.emf.ecore.util.Switch.doSwitch(Switch.java:69)
	at org.eclipse.acceleo.query.parser.AstEvaluator.eval(AstEvaluator.java:109)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.ExpressionEvaluationEngine.eval(ExpressionEvaluationEngine.java:52)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.aqlEval(MethodEvaluator.java:417)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.caseExpressionStatement(MethodEvaluator.java:399)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.throwableSwitch(MethodEvaluator.java:453)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.caseBlock(MethodEvaluator.java:115)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.throwableSwitch(MethodEvaluator.java:450)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.eval(MethodEvaluator.java:92)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.services.EvalBodyService.internalInvoke(EvalBodyService.java:76)
	at org.eclipse.acceleo.query.runtime.impl.AbstractService.invoke(AbstractService.java:135)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.services.NotifyingEvaluationServices.callService(NotifyingEvaluationServices.java:83)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.services.NotifyingEvaluationServices.call(NotifyingEvaluationServices.java:66)
	at org.eclipse.acceleo.query.runtime.impl.EvaluationServices.callOrApply(EvaluationServices.java:208)
	at org.eclipse.acceleo.query.parser.AstEvaluator.caseCall(AstEvaluator.java:189)
	at org.eclipse.acceleo.query.ast.util.AstSwitch.doSwitch(AstSwitch.java:119)
	at org.eclipse.emf.ecore.util.Switch.doSwitch(Switch.java:53)
	at org.eclipse.emf.ecore.util.Switch.doSwitch(Switch.java:69)
	at org.eclipse.acceleo.query.parser.AstEvaluator.eval(AstEvaluator.java:109)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.ExpressionEvaluationEngine.eval(ExpressionEvaluationEngine.java:52)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.aqlEval(MethodEvaluator.java:417)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.caseExpressionStatement(MethodEvaluator.java:399)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.throwableSwitch(MethodEvaluator.java:453)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.caseBlock(MethodEvaluator.java:115)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.throwableSwitch(MethodEvaluator.java:450)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.MethodEvaluator.eval(MethodEvaluator.java:92)
	at org.eclipse.emf.ecoretools.ale.core.interpreter.ALEEngine.eval(ALEEngine.java:31)
	at org.eclipse.emf.ecoretools.ale.ALEInterpreter.doEval(ALEInterpreter.java:260)
	at org.eclipse.emf.ecoretools.ale.ALEInterpreter.eval(ALEInterpreter.java:221)
	at org.eclipse.emf.ecoretools.ale.ide.ui.launchconfig.AleEvaluationJob$1.run(AleEvaluationJob.java:133)
An error occured during evaluation of a query
```

</details>

> Lines are reported in the wrong order, the stacktrace is irrelevant, and useful information are lost in this big chunk of text.

and we now have:



<div align="center">
<img src="https://user-images.githubusercontent.com/25926433/80993416-521bf500-8e3b-11ea-928a-af511759aa89.png" alt="new console"/>
</div>