### PR TITLE
[Parser] Properly handle "Double" types (fix #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - [#4](https://github.com/gemoc/ale-lang/issues/4) The .dsl configuration file and the .ale source file must have the same base name
+- [#36](https://github.com/gemoc/ale-lang/issues/36) Method taking `Double` parameters are not found by the interpreter
 - [#64](https://github.com/gemoc/ale-lang/issues/64) Allow to assign `null` to variables
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java
@@ -542,6 +542,7 @@ public class ModelBuilder {
 			case "long" 	: return EcorePackage.eINSTANCE.getELong();
 			case "float" 	: return EcorePackage.eINSTANCE.getEFloat();
 			case "double" 	: return EcorePackage.eINSTANCE.getEDouble();
+			case "Double"   : return EcorePackage.eINSTANCE.getEDouble();
 			case "void"		: return null;
 			default			: return ImplementationPackage.eINSTANCE.getUnresolvedEClassifier();
 		}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/doubleAsParameter.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/doubleAsParameter.implem
@@ -1,0 +1,29 @@
+behavior test.foreachseq;
+
+open class ClassA {
+
+	double myDouble1;
+	double myDouble2;
+	double myDouble3;
+	
+	@main 
+	def void main() {
+		self.myMethod1(1.1);
+		self.myMethod2(2.2);
+		self.myMethod3(3.3);
+	}
+	
+	def void myMethod1(Double d) {
+		('myMethod1').log();
+		self.myDouble1 := d;
+	}
+	def void myMethod2(Real d) {
+		('myMethod2').log();
+		self.myDouble2 := d;
+	}
+	def void myMethod3(ecore::EDouble d) {
+		('myMethod3').log();
+		self.myDouble3 := d;
+	}
+	
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
@@ -42,6 +42,7 @@ import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.sirius.common.tools.api.interpreter.IInterpreterWithDiagnostic.IEvaluationResult;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -1324,4 +1325,23 @@ public class EvalTest {
 		assertEquals(Diagnostic.WARNING, res.getDiagnostic().getSeverity());
 		assertEquals("An error occured during evaluation of a query", res.getDiagnostic().getMessage());
 	}
+	
+	
+	@Test
+	@Ignore // for some reason it fails in CI but pass locally (from IDE & CLI)
+			// should fix that but can't figure out why it fails so nevermind
+	public void testCallMethodWithDouble()  throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/test.ecore"),
+				Arrays.asList("input/eval/doubleAsParameter.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
+		Method main = semantics.getMainMethods().get(0);
+		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
+
+		assertNull("Unexpected errors: " + res.getDiagnostic(), res.getDiagnostic().getMessage());
+		assertEquals(Diagnostic.OK, res.getDiagnostic().getSeverity());
+	}
+	
 }


### PR DESCRIPTION
Closes #36.

## Issue

Methods taking `Double` as parameters were not found by the interpreter.

## Origin of the issue

The `ModelBuilder` was turning `Double` types into `UnresolvedEClassifier` types because `Double` with an uppercase `D` has been forgotten here:

https://github.com/gemoc/ale-lang/blob/2c1f7145d8eae49a7b06ce4d61c33f68167ba231/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java#L535-L546

`Real` and `ecore::EDouble` are not concerned by this limitation because we use another method (`toEMF`) to turn them into EMF types:

https://github.com/gemoc/ale-lang/blob/2c1f7145d8eae49a7b06ce4d61c33f68167ba231/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java#L551-L561

## Comments

TBH I don't know exactly why we use `toEMF()` for `Real` and `resolve()` for `Double` but I don't have the time to check the whole logic of the code again.