### PR TITLE
Allow the '+=' operator to concatenate collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - [#4](https://github.com/gemoc/ale-lang/issues/4) The .dsl configuration file and the .ale source file must have the same base name
-- [#36](https://github.com/gemoc/ale-lang/issues/36) Method taking `Double` parameters are not found by the interpreter
 - [#64](https://github.com/gemoc/ale-lang/issues/64) Allow to assign `null` to variables
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
+- [#120](https://github.com/gemoc/ale-lang/issues/120) The `+=` cannot be used to concatenate two collections
 
 ### Added
 - [#60](https://github.com/gemoc/ale-lang/issues/60) An ALE Run Configuration is created when launching ALE through the contextual menu shortcut
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#92](https://github.com/gemoc/ale-lang/issues/92) The editor autocompletes attributes and methods of `self`
 - [#94](https://github.com/gemoc/ale-lang/issues/94) The editor automatically switches to dark colors when Eclipse IDE is in dark theme
 - [#98](https://github.com/gemoc/ale-lang/issues/98) The _New ALE Project_ wizard can be used to create ALE projects
+- [#110](https://github.com/gemoc/ale-lang/issues/110) The title of the ALE console is updated as the execution progresses
 - [#115](https://github.com/gemoc/ale-lang/pull/115) Multiple .ale source files can be taken into account when executing an ALE program
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The ALE environment (the _.ale_ source files and the _.ecore_ metamodels) can now be stored in the project's preferences, allowing to get rid of the .dsl configuration file
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The interpreter can be run by right-clicking on an ALE project
@@ -27,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#89](https://github.com/gemoc/ale-lang/pull/89) The bare `List<ParseResult>` objects are abstracted as `DslSemantics` instances **[breaking change]**
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The _.ale_ source files are generated in the `src-ale/` directory
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The _.dsl_ configuration file is generated at the root of the project
+- [#124](https://github.com/gemoc/ale-lang/pull/124) The errors shown in the ALE console are now clean, red stacktraces with hyperlinks to source files
 
 ## [] - 2019-12-08
 ### Changed

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -299,7 +299,12 @@ public class MethodEvaluator {
 				if(feature != null){
 					Object featureValue = ((EObject)assigned).eGet(feature);
 					if(featureValue instanceof EList){
-						((EList)featureValue).add(value);
+						if (value instanceof Collection) {
+							((EList)featureValue).addAll((Collection) value);
+						}
+						else {
+							((EList)featureValue).add(value);
+						}
 					}
 				}
 				else {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -248,7 +248,7 @@ public class MethodEvaluator {
 						new Object[] {varInsert.getValue()}
 				);
 				diagnostic.add(child);
-				throw new CriticalFailure("Unable to insert a value in " + varInsert.getName(), diagnostic);
+				stopExecution(ROOT_ERROR_MESSAGE);
 			}
 		}
 		return null;
@@ -281,7 +281,7 @@ public class MethodEvaluator {
 						new Object[] {varInsert.getValue()}
 				);
 				diagnostic.add(child);
-				throw new CriticalFailure("Unable to remove a value from " + varInsert.getName(), diagnostic);
+				stopExecution(ROOT_ERROR_MESSAGE);
 			}
 		}
 		
@@ -295,27 +295,26 @@ public class MethodEvaluator {
 		if(assigned instanceof EObject){
 			EStructuralFeature feature = ((EObject)assigned).eClass().getEStructuralFeature(featInsert.getTargetFeature());
 			
-			if(feature != null){
-				Object featureValue = ((EObject)assigned).eGet(feature);
-				if(featureValue instanceof EList){
-					((EList)featureValue).add(value);
+			try {
+				if(feature != null){
+					Object featureValue = ((EObject)assigned).eGet(feature);
+					if(featureValue instanceof EList){
+						((EList)featureValue).add(value);
+					}
 				}
-			}
-			else {
-				try {
+				else {
 					dynamicFeatureAccess.insertDynamicFeatureValue(((EObject)assigned),featInsert.getTargetFeature(),value);
-				
-				} catch (ArrayStoreException e) {
-					BasicDiagnostic child = new BasicDiagnostic(
-							Diagnostic.ERROR,
-							MethodEvaluator.PLUGIN_ID,
-							0,
-							String.format("Cannot add the value to '%s': types mismatch", featInsert.getTargetFeature()),
-							new Object[] {featInsert.getTarget()}
-					);
-					diagnostic.add(child);
-					throw new CriticalFailure("Cannot add the value to '" + featInsert.getTargetFeature() + "': types mismatch", diagnostic);
 				}
+			} catch (ArrayStoreException e) {
+				BasicDiagnostic child = new BasicDiagnostic(
+						Diagnostic.ERROR,
+						MethodEvaluator.PLUGIN_ID,
+						0,
+						String.format("Cannot add the value to '%s': types mismatch", featInsert.getTargetFeature()),
+						new Object[] {featInsert.getTarget()}
+						);
+				diagnostic.add(child);
+				stopExecution(ROOT_ERROR_MESSAGE);
 			}
 		}
 		return null;

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/addAllCollectionWithOperator.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/addAllCollectionWithOperator.implem
@@ -1,0 +1,38 @@
+behavior test.containattributes;
+
+open class Mix {
+
+	Sequence(String) dynStrings := Sequence{6, 5, 4};
+
+	@main
+	def void concatWithStaticAttribute() {
+		self.strings += Sequence{'one', 'two', 'three'};
+	}
+	
+	@main
+	def void concatWrongTypeWithStaticAttribute() {
+		self.strings += Sequence{1, 2, 3};
+	}
+
+	@main
+	def void concatWithDynamicAttribute() {
+		self.dynStrings += Sequence{'one', 'two', 'three'};
+	}
+	
+	@main
+	def void concatWrongTypeWithDynamicAttribute() {
+		self.dynStrings += Sequence{1, 2, 3};
+	}
+
+	@main
+	def void concatWithLocalVariable() {
+		Sequence(Integer) localNumbers := Sequence{1, 2, 3};
+		localNumbers += Sequence{4, 5, 6};
+	}
+	
+	@main
+	def void concatWrongTypeWithLocalVariable() {
+		Sequence(Integer) localNumbers := Sequence{1, 2, 3};
+		localNumbers += Sequence{'four', 'five', 'six'};
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
@@ -1344,4 +1344,98 @@ public class EvalTest {
 		assertEquals(Diagnostic.OK, res.getDiagnostic().getSeverity());
 	}
 	
+	@Test
+	public void testCanAddAllToStaticCollectionAttribute()  throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"),
+				Arrays.asList("input/eval/addAllCollectionWithOperator.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		Method main = semantics.getMainMethods().stream().filter(m -> m.getOperationRef().getName().equals("concatWithStaticAttribute")).findAny().get();
+		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
+
+		assertNull("Unexpected errors: " + res.getDiagnostic(), res.getDiagnostic().getMessage());
+		assertEquals(Diagnostic.OK, res.getDiagnostic().getSeverity());
+	}
+	
+	@Test
+	public void testCannotAddAllDifferentCollectionTypeToStaticCollectionAttribute()  throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"),
+				Arrays.asList("input/eval/addAllCollectionWithOperator.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		Method main = semantics.getMainMethods().stream().filter(m -> m.getOperationRef().getName().equals("concatWrongTypeWithStaticAttribute")).findAny().get();
+		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
+
+		assertEquals("Cannot add the value to 'strings': types mismatch", res.getDiagnostic().getMessage());
+		assertEquals(Diagnostic.ERROR, res.getDiagnostic().getSeverity());
+	}
+	
+	@Test
+	public void testCanAddAllDynamicCollectionAttribute()  throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"),
+				Arrays.asList("input/eval/addAllCollectionWithOperator.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		Method main = semantics.getMainMethods().stream().filter(m -> m.getOperationRef().getName().equals("concatWithDynamicAttribute")).findAny().get();
+		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
+
+		assertNull("Unexpected errors: " + res.getDiagnostic(), res.getDiagnostic().getMessage());
+		assertEquals(Diagnostic.OK, res.getDiagnostic().getSeverity());
+	}
+	
+	@Test
+	@Ignore // This test fails but we currently have no easy way to fix it
+			// see https://github.com/gemoc/ale-lang/issues/127
+	public void testCannotAddAllDifferentCollectionTypeToDynamicCollectionAttribute()  throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"),
+				Arrays.asList("input/eval/addAllCollectionWithOperator.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		Method main = semantics.getMainMethods().stream().filter(m -> m.getOperationRef().getName().equals("concatWrongTypeWithDynamicAttribute")).findAny().get();
+		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
+
+		assertEquals("Cannot add the value to 'dynStrings': types mismatch", res.getDiagnostic().getMessage());
+		assertEquals(Diagnostic.ERROR, res.getDiagnostic().getSeverity());
+	}
+	
+	@Test
+	public void testCanAddAllLocalCollectionVariable()  throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"),
+				Arrays.asList("input/eval/addAllCollectionWithOperator.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		Method main = semantics.getMainMethods().stream().filter(m -> m.getOperationRef().getName().equals("concatWithLocalVariable")).findAny().get();
+		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
+
+		assertNull("Unexpected errors: " + res.getDiagnostic(), res.getDiagnostic().getMessage());
+		assertEquals(Diagnostic.OK, res.getDiagnostic().getSeverity());
+	}
+	
+	@Test
+	@Ignore // This test fails but we currently have no easy way to fix it
+			// see https://github.com/gemoc/ale-lang/issues/128
+	public void testCannotAddAllDifferentCollectionTypeToLocalCollectionVariable()  throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"),
+				Arrays.asList("input/eval/addAllCollectionWithOperator.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		Method main = semantics.getMainMethods().stream().filter(m -> m.getOperationRef().getName().equals("concatWrongTypeWithLocalVariable")).findAny().get();
+		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
+
+		assertEquals("Cannot add the value to 'localNumbers': types mismatch", res.getDiagnostic().getMessage());
+		assertEquals(Diagnostic.ERROR, res.getDiagnostic().getSeverity());
+	}
+	
 }


### PR DESCRIPTION
Closes #120.

Allows to use the `+=` operator on local variables and static attributes (declared in Ecore) when both operands are collections.

Helped to identify issue #128 (no runtime error when the collections hold incompatible types).