### PR TITLE
Properly turn AQL declarations into EMF objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#115](https://github.com/gemoc/ale-lang/pull/115) Multiple .ale source files can be taken into account when executing an ALE program
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The ALE environment (the _.ale_ source files and the _.ecore_ metamodels) can now be stored in the project's preferences, allowing to get rid of the .dsl configuration file
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The interpreter can be run by right-clicking on an ALE project
+- [#129](https://github.com/gemoc/ale-lang/pull/129) The editor warns when the `+=` and `-=` operators ared used on the `result` variable in a void method
 
 ### Changed
 - [#93](https://github.com/gemoc/ale-lang/issues/93) More tokens are available to tailor editor's syntax coloring

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DynamicFeatureRegistry.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/DynamicFeatureRegistry.java
@@ -141,7 +141,12 @@ public class DynamicFeatureRegistry {
 			if(feature != null) {
 				Object featureValue = extendedInstance.eGet(feature);
 				if(featureValue instanceof List){
-					((List)featureValue).add(newValue);
+					if (newValue instanceof Collection) {
+						((List) featureValue).addAll((Collection) newValue);
+					}
+					else {
+						((List)featureValue).add(newValue);
+					}
 				}
 				else if(featureValue instanceof String){
 					String concat = featureValue + "" + newValue;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -542,8 +542,8 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 		return qryEnv;
 	}
 	
-	public Method getContainingOperation(VariableAssignment varAssign) {
-		EObject parent = varAssign.eContainer();
+	public Method getContainingOperation(Statement statement) {
+		EObject parent = statement.eContainer();
 		while(parent != null && !(parent instanceof Method)){
 			parent = parent.eContainer();
 		}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IConvertType.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IConvertType.java
@@ -12,6 +12,7 @@ package org.eclipse.emf.ecoretools.ale.core.validation;
 
 import java.util.Optional;
 
+import org.eclipse.acceleo.query.ast.TypeLiteral;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.acceleo.query.validation.type.NothingType;
 import org.eclipse.acceleo.query.validation.type.SequenceType;
@@ -20,6 +21,7 @@ import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecoretools.ale.implementation.UnresolvedEClassifier;
 
 /**
  * Performs conversions between AQL's {@link IType} and EMF's {@link EClassifier}.
@@ -89,5 +91,27 @@ public interface IConvertType {
 	 * 		   if able to convert it
 	 */
 	Optional<EClassifier> toEMF(IType type);
+
+	/**
+	 * Attempts to turn an AQL type literal into an EMF classifier.
+	 * 
+	 * @param typeLiteral
+	 * 			The AQL type literal to convert
+	 * 
+	 * @return the EMF classifier corresponding to the given AQL literal type
+	 * 		   if able to convert it
+	 */
+	Optional<EClassifier> toEMF(TypeLiteral typeLiteral);
+
+	/**
+	 * Turns a Java class into an EMF classifier.
+	 * 
+	 * @param type
+	 * 			The class to convert
+	 * 
+	 * @return the EMF classifier corresponding to the given class if able to convert it,
+	 * 		   {@link UnresolvedEClassifier} otherwise
+	 */
+	EClassifier toEMF(Class<?> type);
 	
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidationMessageFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/IValidationMessageFactory.java
@@ -16,10 +16,9 @@ import org.eclipse.acceleo.query.ast.Expression;
 import org.eclipse.acceleo.query.runtime.IValidationMessage;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecoretools.ale.implementation.Attribute;
 import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
 import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
-import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
+import org.eclipse.emf.ecoretools.ale.implementation.Statement;
 
 /**
  * A factory that creates new, tailored, {@link IValidationMessage validation messages}.
@@ -40,7 +39,7 @@ public interface IValidationMessageFactory {
 	 * 
 	 * @return a new validation message
 	 */
-	IValidationMessage assignmentToResultInVoidOperation(VariableAssignment assignment);
+	IValidationMessage assignmentToResultInVoidOperation(Statement statement);
 	
 	/**
 	 * Creates a message telling that an expression was supposed to be boolean.

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
@@ -483,8 +483,6 @@ public class NameValidator implements IValidator {
 				boolean assigningToResult = "result".equals(varAssign.getName());
 				boolean isVoidOperation = enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null;
 				if(assigningToResult && isVoidOperation) {
-					// A void operation should not return anything
-					// FIXME Should be in the NameValidator
 					IValidationMessage invalidAssignment = messages.assignmentToResultInVoidOperation(varAssign);
 					msgs.add(invalidAssignment);
 					return msgs;
@@ -536,17 +534,31 @@ public class NameValidator implements IValidator {
 	public List<IValidationMessage> validateVariableInsert(VariableInsert varInsert) {
 		List<IValidationMessage> msgs = new ArrayList<>();
 		
-		/*
-		 * Check name
-		 */
+		boolean assigningToResult = "result".equals(varInsert.getName());
 		Set<IType> declaringTypes = base.getCurrentScope().get(varInsert.getName());
-		if(declaringTypes == null && !varInsert.getName().equals("result")){
+
+		if(declaringTypes == null && !assigningToResult){
 			msgs.add(new ValidationMessage(
 					ValidationMessageLevel.ERROR,
 					String.format(VARIABLE_UNDEFINED,varInsert.getName()),
 					base.getStartOffset(varInsert),
 					base.getEndOffset(varInsert)
 					));
+		}
+		else if (assigningToResult) {
+			// Check attempts to assign 'result' in a void operation
+			
+			Method method = base.getContainingOperation(varInsert);
+			EOperation enclosingOperation = method.getOperationRef();
+			
+			if (enclosingOperation != null) {
+				boolean isVoidOperation = enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null;
+				if(isVoidOperation) {
+					IValidationMessage invalidAssignment = messages.assignmentToResultInVoidOperation(varInsert);
+					msgs.add(invalidAssignment);
+					return msgs;
+				}
+			}
 		}
 		return msgs;
 	}
@@ -555,17 +567,31 @@ public class NameValidator implements IValidator {
 	public List<IValidationMessage> validateVariableRemove(VariableRemove varRemove) {
 		List<IValidationMessage> msgs = new ArrayList<>();
 		
-		/*
-		 * Check name
-		 */
+		boolean assigningToResult = "result".equals(varRemove.getName());
 		Set<IType> declaringTypes = base.getCurrentScope().get(varRemove.getName());
-		if(declaringTypes == null && !varRemove.getName().equals("result")){
+		
+		if(declaringTypes == null && !assigningToResult){
 			msgs.add(new ValidationMessage(
 					ValidationMessageLevel.ERROR,
 					String.format(VARIABLE_UNDEFINED,varRemove.getName()),
 					base.getStartOffset(varRemove),
 					base.getEndOffset(varRemove)
 					));
+		}
+		else if (assigningToResult) {
+			// Check attempts to assign 'result' in a void operation
+			
+			Method method = base.getContainingOperation(varRemove);
+			EOperation enclosingOperation = method.getOperationRef();
+			
+			if (enclosingOperation != null) {
+				boolean isVoidOperation = enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null;
+				if(isVoidOperation) {
+					IValidationMessage invalidAssignment = messages.assignmentToResultInVoidOperation(varRemove);
+					msgs.add(invalidAssignment);
+					return msgs;
+				}
+			}
 		}
 		return msgs;
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
@@ -26,7 +26,6 @@ import org.eclipse.acceleo.query.validation.type.SequenceType;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EGenericType;
-import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ValidationMessageFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ValidationMessageFactory.java
@@ -27,7 +27,7 @@ import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
 import org.eclipse.emf.ecoretools.ale.core.validation.IValidationMessageFactory;
 import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
 import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
-import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
+import org.eclipse.emf.ecoretools.ale.implementation.Statement;
 
 public final class ValidationMessageFactory implements IValidationMessageFactory {
 
@@ -40,7 +40,7 @@ public final class ValidationMessageFactory implements IValidationMessageFactory
 	public static final String INCOMPATIBLE_TYPES = "Expected %s but was %s";
 	public static final String INDIRECT_EXTENSION = "Can't extend %s since it is not a direct super type of %s";
 	public static final String UNSUPPORTED_OPERATOR = "%s does not support the '%s' operator";
-	public static final String VOID_RESULT_ASSIGN = "Cannot assign 'result' in a void operation";
+	public static final String VOID_RESULT_ASSIGN = "'result' is not available in a void method. Change method's return type";
 	public static final String UNRESOLVED_TYPE = "Unresolved type %s, it cannot be found in any of the declared packages: %s";
 	
 	private final BaseValidator base;
@@ -50,10 +50,10 @@ public final class ValidationMessageFactory implements IValidationMessageFactory
 	}
 	
 	@Override
-	public IValidationMessage assignmentToResultInVoidOperation(VariableAssignment assignment) {
+	public IValidationMessage assignmentToResultInVoidOperation(Statement assignment) {
 		return new ValidationMessage(
 				ValidationMessageLevel.ERROR,
-				String.format(VOID_RESULT_ASSIGN,assignment.getName()),
+				VOID_RESULT_ASSIGN,
 				base.getStartOffset(assignment),
 				base.getEndOffset(assignment)
 		);

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignVoid.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignVoid.implem
@@ -1,6 +1,8 @@
 behavior test.localAssign;
 open class EClass {
 	def void op(){
+		result += 4;
+		result -= 4;
 		result := 4;
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
@@ -815,8 +815,9 @@ public class EvalTest {
 		EObject caller = interpreter.loadModel("model/ClassA.xmi").getContents().get(0);
 		Method main = semantics.getMainMethods().get(0);
 		IEvaluationResult res = interpreter.eval(caller, main, Arrays.asList(), semantics);
-
-		assertTrue(res.getValue() instanceof EObject);
+		Object value = res.getValue();
+		
+		assertTrue("got: " + (value == null ? "null" : value.getClass()) + ", expected: EObject", res.getValue() instanceof EObject);
 		assertNotEquals(caller, res.getValue());
 		assertEquals("NewClass", ((EObject) res.getValue()).eClass().getName());
 	}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/parser/test/BuildTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/parser/test/BuildTest.java
@@ -40,6 +40,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.IAleEnvironment;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.impl.RuntimeAleEnvironment;
@@ -769,13 +770,19 @@ public class BuildTest {
 		assertNull(attrib3.getInitialValue());
 		
 		Attribute attrib4 = xtdCls.getAttributes().get(4);
-		assertEquals("seqAttr", attrib4.getFeatureRef().getName());
-		assertEquals(EcorePackage.eINSTANCE.getEEList(), attrib4.getFeatureRef().getEType());
+		EStructuralFeature attrib4Feature = attrib4.getFeatureRef();
+		assertEquals("seqAttr", attrib4Feature.getName());
+		assertEquals(0, attrib4Feature.getLowerBound());
+		assertEquals(-1, attrib4Feature.getUpperBound());
+		assertEquals(EcorePackage.eINSTANCE.getEString(), attrib4Feature.getEType());
 		assertNull(attrib4.getInitialValue());
 		
 		Attribute attrib5 = xtdCls.getAttributes().get(5);
-		assertEquals("setAttr", attrib5.getFeatureRef().getName());
-		assertEquals(EcorePackage.eINSTANCE.getEEList(), attrib5.getFeatureRef().getEType());
+		EStructuralFeature attrib5FeatureRef = attrib5.getFeatureRef();
+		assertEquals("setAttr", attrib5FeatureRef.getName());
+		assertEquals(0, attrib5FeatureRef.getLowerBound());
+		assertEquals(-1, attrib5FeatureRef.getUpperBound());
+		assertEquals(EcorePackage.eINSTANCE.getEString(), attrib5FeatureRef.getEType());
 		assertNull(attrib5.getInitialValue());
 		
 		Attribute attrib6 = xtdCls.getAttributes().get(6);

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
@@ -904,7 +904,7 @@ public class NameValidatorTest {
 	}
 	
 	/*
-	 * Test value of result conflict the return type void
+	 * Test that no value can be assigned (:=, ++, -=) to the 'result' variable
 	 */
 	@Test
 	public void testReturnAssignVoid() {
@@ -916,7 +916,9 @@ public class NameValidatorTest {
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
-		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 65, 76, "Cannot assign 'result' in a void operation", msg.get(0));
+		assertEquals(3, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 65, 76, "'result' is not available in a void method. Change method's return type", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 80, 91, "'result' is not available in a void method. Change method's return type", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 95, 106, "'result' is not available in a void method. Change method's return type", msg.get(2));
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -323,23 +323,6 @@ public class TypeValidatorTest {
 	}
 	
 	/*
-	 * Test value of result conflict the return type void
-	 */
-	@Test
-	public void testReturnAssignVoid() {
-		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList(),Arrays.asList("input/validation/assignVoid.implem"));
-		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
-		
-		
-		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
-		validator.validate(parsedSemantics);
-		List<IValidationMessage> msg = validator.getMessages();
-		
-		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 65, 76, "Cannot assign 'result' in a void operation", msg.get(0));
-	}
-	
-	/*
 	 * Test assigned value doesn't conflict the feature type of the baseClass
 	 */
 	@Test


### PR DESCRIPTION
## Main changes

Little refactor of the parser (`ModelBuilder`) to create a cleaner EMF model.

As of now, AQL collections are turned into EDataType instances holding an EEList type and with bounds [0, 1]. This commit turns collections into ETypedElement holding the actual type with relevant bounds instead.

This homogenize datatypes and should ease further developments, e.g. to handle Sets properly (#67).

## Bonus

Also provides a little enhancement: using `+=` or `-=` on the `result` variable within a void operation now leads to the following error: _'result' is not available in a void method. Change method's return type_.

The error was already shown when using the `:=` operator.