### PR TITLE
[Editor | Interpreter] Enforce assignment of OrderedSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - [#4](https://github.com/gemoc/ale-lang/issues/4) The .dsl configuration file and the .ale source file must have the same base name
 - [#64](https://github.com/gemoc/ale-lang/issues/64) Allow to assign `null` to variables
+- [#67](https://github.com/gemoc/ale-lang/issues/67) Forbid assignments from `Sequence` to `OrderedSet` and vice versa
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
 - [#120](https://github.com/gemoc/ale-lang/issues/120) The `+=` cannot be used to concatenate two collections
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.ecore
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.ecore
@@ -52,11 +52,9 @@
   <eClassifiers xsi:type="ecore:EClass" name="Statement"/>
   <eClassifiers xsi:type="ecore:EClass" name="VariableDeclaration" eSuperTypes="#//Statement">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="type" lowerBound="1" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EClassifier"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" lowerBound="1" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//ETypedElement"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="initialValue" eType="ecore:EClass ../../org.eclipse.acceleo.query/model/ast.ecore#//Expression"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="typeParameter" lowerBound="1"
-        eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EClassifier"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Assignment" eSuperTypes="#//Statement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="value" lowerBound="1" eType="ecore:EClass ../../org.eclipse.acceleo.query/model/ast.ecore#//Expression"

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.genmodel
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.genmodel
@@ -47,7 +47,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Implementation.ecore#//VariableDeclaration/name"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Implementation.ecore#//VariableDeclaration/type"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Implementation.ecore#//VariableDeclaration/initialValue"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Implementation.ecore#//VariableDeclaration/typeParameter"/>
     </genClasses>
     <genClasses ecoreClass="Implementation.ecore#//Assignment">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Implementation.ecore#//Assignment/value"/>

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/ImplementationPackage.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/ImplementationPackage.java
@@ -697,22 +697,13 @@ public interface ImplementationPackage extends EPackage {
 	int VARIABLE_DECLARATION__INITIAL_VALUE = STATEMENT_FEATURE_COUNT + 2;
 
 	/**
-	 * The feature id for the '<em><b>Type Parameter</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int VARIABLE_DECLARATION__TYPE_PARAMETER = STATEMENT_FEATURE_COUNT + 3;
-
-	/**
 	 * The number of structural features of the '<em>Variable Declaration</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int VARIABLE_DECLARATION_FEATURE_COUNT = STATEMENT_FEATURE_COUNT + 4;
+	int VARIABLE_DECLARATION_FEATURE_COUNT = STATEMENT_FEATURE_COUNT + 3;
 
 	/**
 	 * The number of operations of the '<em>Variable Declaration</em>' class.
@@ -1819,17 +1810,6 @@ public interface ImplementationPackage extends EPackage {
 	EReference getVariableDeclaration_InitialValue();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getTypeParameter <em>Type Parameter</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the reference '<em>Type Parameter</em>'.
-	 * @see org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getTypeParameter()
-	 * @see #getVariableDeclaration()
-	 * @generated
-	 */
-	EReference getVariableDeclaration_TypeParameter();
-
-	/**
 	 * Returns the meta object for class '{@link org.eclipse.emf.ecoretools.ale.implementation.Assignment <em>Assignment</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2601,14 +2581,6 @@ public interface ImplementationPackage extends EPackage {
 		 * @generated
 		 */
 		EReference VARIABLE_DECLARATION__INITIAL_VALUE = eINSTANCE.getVariableDeclaration_InitialValue();
-
-		/**
-		 * The meta object literal for the '<em><b>Type Parameter</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @generated
-		 */
-		EReference VARIABLE_DECLARATION__TYPE_PARAMETER = eINSTANCE.getVariableDeclaration_TypeParameter();
 
 		/**
 		 * The meta object literal for the '{@link org.eclipse.emf.ecoretools.ale.implementation.impl.AssignmentImpl <em>Assignment</em>}' class.

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/VariableDeclaration.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/VariableDeclaration.java
@@ -12,8 +12,7 @@
 package org.eclipse.emf.ecoretools.ale.implementation;
 
 import org.eclipse.acceleo.query.ast.Expression;
-
-import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.ETypedElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -27,7 +26,6 @@ import org.eclipse.emf.ecore.EClassifier;
  *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getName <em>Name</em>}</li>
  *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getInitialValue <em>Initial Value</em>}</li>
- *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getTypeParameter <em>Type Parameter</em>}</li>
  * </ul>
  *
  * @see org.eclipse.emf.ecoretools.ale.implementation.ImplementationPackage#getVariableDeclaration()
@@ -77,12 +75,12 @@ public interface VariableDeclaration extends Statement {
 	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Type</em>' reference.
-	 * @see #setType(EClassifier)
+	 * @see #setType(ETypedElement)
 	 * @see org.eclipse.emf.ecoretools.ale.implementation.ImplementationPackage#getVariableDeclaration_Type()
 	 * @model required="true"
 	 * @generated
 	 */
-	EClassifier getType();
+	ETypedElement getType();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getType <em>Type</em>}' reference.
@@ -92,7 +90,7 @@ public interface VariableDeclaration extends Statement {
 	 * @see #getType()
 	 * @generated
 	 */
-	void setType(EClassifier value);
+	void setType(ETypedElement value);
 
 	/**
 	 * Returns the value of the '<em><b>Initial Value</b></em>' containment reference.
@@ -119,31 +117,5 @@ public interface VariableDeclaration extends Statement {
 	 * @generated
 	 */
 	void setInitialValue(Expression value);
-
-	/**
-	 * Returns the value of the '<em><b>Type Parameter</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Type Parameter</em>' reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
-	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Type Parameter</em>' reference.
-	 * @see #setTypeParameter(EClassifier)
-	 * @see org.eclipse.emf.ecoretools.ale.implementation.ImplementationPackage#getVariableDeclaration_TypeParameter()
-	 * @model required="true"
-	 * @generated
-	 */
-	EClassifier getTypeParameter();
-
-	/**
-	 * Sets the value of the '{@link org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration#getTypeParameter <em>Type Parameter</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Type Parameter</em>' reference.
-	 * @see #getTypeParameter()
-	 * @generated
-	 */
-	void setTypeParameter(EClassifier value);
 
 } // VariableDeclaration

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/AssignmentImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/AssignmentImpl.java
@@ -79,6 +79,7 @@ public class AssignmentImpl extends StatementImpl implements Assignment {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getValue() {
 		return value;
 	}
@@ -103,6 +104,7 @@ public class AssignmentImpl extends StatementImpl implements Assignment {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setValue(Expression newValue) {
 		if (newValue != value) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/AttributeImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/AttributeImpl.java
@@ -91,6 +91,7 @@ public class AttributeImpl extends EModelElementImpl implements Attribute {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EStructuralFeature getFeatureRef() {
 		if (featureRef != null && featureRef.eIsProxy()) {
 			InternalEObject oldFeatureRef = (InternalEObject)featureRef;
@@ -117,6 +118,7 @@ public class AttributeImpl extends EModelElementImpl implements Attribute {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setFeatureRef(EStructuralFeature newFeatureRef) {
 		EStructuralFeature oldFeatureRef = featureRef;
 		featureRef = newFeatureRef;
@@ -129,6 +131,7 @@ public class AttributeImpl extends EModelElementImpl implements Attribute {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getInitialValue() {
 		return initialValue;
 	}
@@ -153,6 +156,7 @@ public class AttributeImpl extends EModelElementImpl implements Attribute {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setInitialValue(Expression newInitialValue) {
 		if (newInitialValue != initialValue) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/BehavioredClassImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/BehavioredClassImpl.java
@@ -108,6 +108,7 @@ public abstract class BehavioredClassImpl extends ENamedElementImpl implements B
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Method> getMethods() {
 		if (methods == null) {
 			methods = new EObjectContainmentEList<Method>(Method.class, this, ImplementationPackage.BEHAVIORED_CLASS__METHODS);
@@ -120,6 +121,7 @@ public abstract class BehavioredClassImpl extends ENamedElementImpl implements B
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Attribute> getAttributes() {
 		if (attributes == null) {
 			attributes = new EObjectContainmentEList<Attribute>(Attribute.class, this, ImplementationPackage.BEHAVIORED_CLASS__ATTRIBUTES);
@@ -132,6 +134,7 @@ public abstract class BehavioredClassImpl extends ENamedElementImpl implements B
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFragment() {
 		return fragment;
 	}
@@ -156,6 +159,7 @@ public abstract class BehavioredClassImpl extends ENamedElementImpl implements B
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setFragment(EClass newFragment) {
 		if (newFragment != fragment) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/BlockImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/BlockImpl.java
@@ -82,6 +82,7 @@ public class BlockImpl extends StatementImpl implements Block {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Statement> getStatements() {
 		if (statements == null) {
 			statements = new EObjectContainmentEList<Statement>(Statement.class, this, ImplementationPackage.BLOCK__STATEMENTS);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/CaseImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/CaseImpl.java
@@ -103,6 +103,7 @@ public class CaseImpl extends MinimalEObjectImpl.Container implements Case {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClassifier getGuard() {
 		if (guard != null && guard.eIsProxy()) {
 			InternalEObject oldGuard = (InternalEObject)guard;
@@ -129,6 +130,7 @@ public class CaseImpl extends MinimalEObjectImpl.Container implements Case {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setGuard(EClassifier newGuard) {
 		EClassifier oldGuard = guard;
 		guard = newGuard;
@@ -141,6 +143,7 @@ public class CaseImpl extends MinimalEObjectImpl.Container implements Case {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getMatch() {
 		return match;
 	}
@@ -165,6 +168,7 @@ public class CaseImpl extends MinimalEObjectImpl.Container implements Case {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setMatch(Expression newMatch) {
 		if (newMatch != match) {
 			NotificationChain msgs = null;
@@ -184,6 +188,7 @@ public class CaseImpl extends MinimalEObjectImpl.Container implements Case {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getValue() {
 		return value;
 	}
@@ -208,6 +213,7 @@ public class CaseImpl extends MinimalEObjectImpl.Container implements Case {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setValue(Expression newValue) {
 		if (newValue != value) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ConditionalBlockImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ConditionalBlockImpl.java
@@ -91,6 +91,7 @@ public class ConditionalBlockImpl extends StatementImpl implements ConditionalBl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getCondition() {
 		return condition;
 	}
@@ -115,6 +116,7 @@ public class ConditionalBlockImpl extends StatementImpl implements ConditionalBl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setCondition(Expression newCondition) {
 		if (newCondition != condition) {
 			NotificationChain msgs = null;
@@ -134,6 +136,7 @@ public class ConditionalBlockImpl extends StatementImpl implements ConditionalBl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Block getBlock() {
 		return block;
 	}
@@ -158,6 +161,7 @@ public class ConditionalBlockImpl extends StatementImpl implements ConditionalBl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setBlock(Block newBlock) {
 		if (newBlock != block) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ExpressionStatementImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ExpressionStatementImpl.java
@@ -79,6 +79,7 @@ public class ExpressionStatementImpl extends StatementImpl implements Expression
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getExpression() {
 		return expression;
 	}
@@ -103,6 +104,7 @@ public class ExpressionStatementImpl extends StatementImpl implements Expression
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setExpression(Expression newExpression) {
 		if (newExpression != expression) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ExtendedClassImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ExtendedClassImpl.java
@@ -103,6 +103,7 @@ public class ExtendedClassImpl extends BehavioredClassImpl implements ExtendedCl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getBaseClass() {
 		if (baseClass != null && baseClass.eIsProxy()) {
 			InternalEObject oldBaseClass = (InternalEObject)baseClass;
@@ -129,6 +130,7 @@ public class ExtendedClassImpl extends BehavioredClassImpl implements ExtendedCl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setBaseClass(EClass newBaseClass) {
 		EClass oldBaseClass = baseClass;
 		baseClass = newBaseClass;
@@ -141,6 +143,7 @@ public class ExtendedClassImpl extends BehavioredClassImpl implements ExtendedCl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<ExtendedClass> getExtends() {
 		if (extends_ == null) {
 			extends_ = new EObjectWithInverseResolvingEList.ManyInverse<ExtendedClass>(ExtendedClass.class, this, ImplementationPackage.EXTENDED_CLASS__EXTENDS, ImplementationPackage.EXTENDED_CLASS__CHILDREN);
@@ -153,6 +156,7 @@ public class ExtendedClassImpl extends BehavioredClassImpl implements ExtendedCl
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<ExtendedClass> getChildren() {
 		if (children == null) {
 			children = new EObjectWithInverseResolvingEList.ManyInverse<ExtendedClass>(ExtendedClass.class, this, ImplementationPackage.EXTENDED_CLASS__CHILDREN, ImplementationPackage.EXTENDED_CLASS__EXTENDS);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeatureAssignmentImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeatureAssignmentImpl.java
@@ -99,6 +99,7 @@ public class FeatureAssignmentImpl extends AssignmentImpl implements FeatureAssi
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getTarget() {
 		return target;
 	}
@@ -123,6 +124,7 @@ public class FeatureAssignmentImpl extends AssignmentImpl implements FeatureAssi
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTarget(Expression newTarget) {
 		if (newTarget != target) {
 			NotificationChain msgs = null;
@@ -142,6 +144,7 @@ public class FeatureAssignmentImpl extends AssignmentImpl implements FeatureAssi
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getTargetFeature() {
 		return targetFeature;
 	}
@@ -151,6 +154,7 @@ public class FeatureAssignmentImpl extends AssignmentImpl implements FeatureAssi
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTargetFeature(String newTargetFeature) {
 		String oldTargetFeature = targetFeature;
 		targetFeature = newTargetFeature;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeatureInsertImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeatureInsertImpl.java
@@ -100,6 +100,7 @@ public class FeatureInsertImpl extends AssignmentImpl implements FeatureInsert {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getTarget() {
 		return target;
 	}
@@ -124,6 +125,7 @@ public class FeatureInsertImpl extends AssignmentImpl implements FeatureInsert {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTarget(Expression newTarget) {
 		if (newTarget != target) {
 			NotificationChain msgs = null;
@@ -143,6 +145,7 @@ public class FeatureInsertImpl extends AssignmentImpl implements FeatureInsert {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getTargetFeature() {
 		return targetFeature;
 	}
@@ -152,6 +155,7 @@ public class FeatureInsertImpl extends AssignmentImpl implements FeatureInsert {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTargetFeature(String newTargetFeature) {
 		String oldTargetFeature = targetFeature;
 		targetFeature = newTargetFeature;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeaturePutImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeaturePutImpl.java
@@ -122,6 +122,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getTarget() {
 		return target;
 	}
@@ -146,6 +147,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTarget(Expression newTarget) {
 		if (newTarget != target) {
 			NotificationChain msgs = null;
@@ -165,6 +167,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getTargetFeature() {
 		return targetFeature;
 	}
@@ -174,6 +177,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTargetFeature(String newTargetFeature) {
 		String oldTargetFeature = targetFeature;
 		targetFeature = newTargetFeature;
@@ -186,6 +190,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getKey() {
 		return key;
 	}
@@ -210,6 +215,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setKey(Expression newKey) {
 		if (newKey != key) {
 			NotificationChain msgs = null;
@@ -229,6 +235,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getValue() {
 		return value;
 	}
@@ -253,6 +260,7 @@ public class FeaturePutImpl extends StatementImpl implements FeaturePut {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setValue(Expression newValue) {
 		if (newValue != value) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeatureRemoveImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/FeatureRemoveImpl.java
@@ -100,6 +100,7 @@ public class FeatureRemoveImpl extends AssignmentImpl implements FeatureRemove {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getTarget() {
 		return target;
 	}
@@ -124,6 +125,7 @@ public class FeatureRemoveImpl extends AssignmentImpl implements FeatureRemove {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTarget(Expression newTarget) {
 		if (newTarget != target) {
 			NotificationChain msgs = null;
@@ -143,6 +145,7 @@ public class FeatureRemoveImpl extends AssignmentImpl implements FeatureRemove {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getTargetFeature() {
 		return targetFeature;
 	}
@@ -152,6 +155,7 @@ public class FeatureRemoveImpl extends AssignmentImpl implements FeatureRemove {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setTargetFeature(String newTargetFeature) {
 		String oldTargetFeature = targetFeature;
 		targetFeature = newTargetFeature;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ForEachImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ForEachImpl.java
@@ -112,6 +112,7 @@ public class ForEachImpl extends StatementImpl implements ForEach {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getVariable() {
 		return variable;
 	}
@@ -121,6 +122,7 @@ public class ForEachImpl extends StatementImpl implements ForEach {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setVariable(String newVariable) {
 		String oldVariable = variable;
 		variable = newVariable;
@@ -133,6 +135,7 @@ public class ForEachImpl extends StatementImpl implements ForEach {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getCollectionExpression() {
 		return collectionExpression;
 	}
@@ -157,6 +160,7 @@ public class ForEachImpl extends StatementImpl implements ForEach {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setCollectionExpression(Expression newCollectionExpression) {
 		if (newCollectionExpression != collectionExpression) {
 			NotificationChain msgs = null;
@@ -176,6 +180,7 @@ public class ForEachImpl extends StatementImpl implements ForEach {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Block getBody() {
 		return body;
 	}
@@ -200,6 +205,7 @@ public class ForEachImpl extends StatementImpl implements ForEach {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setBody(Block newBody) {
 		if (newBody != body) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/IfImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/IfImpl.java
@@ -94,6 +94,7 @@ public class IfImpl extends StatementImpl implements If {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<ConditionalBlock> getBlocks() {
 		if (blocks == null) {
 			blocks = new EObjectContainmentEList<ConditionalBlock>(ConditionalBlock.class, this, ImplementationPackage.IF__BLOCKS);
@@ -106,6 +107,7 @@ public class IfImpl extends StatementImpl implements If {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Block getElse() {
 		return else_;
 	}
@@ -130,6 +132,7 @@ public class IfImpl extends StatementImpl implements If {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setElse(Block newElse) {
 		if (newElse != else_) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationFactoryImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationFactoryImpl.java
@@ -107,6 +107,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ModelBehavior createModelBehavior() {
 		ModelBehaviorImpl modelBehavior = new ModelBehaviorImpl();
 		return modelBehavior;
@@ -117,6 +118,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ExtendedClass createExtendedClass() {
 		ExtendedClassImpl extendedClass = new ExtendedClassImpl();
 		return extendedClass;
@@ -127,6 +129,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public RuntimeClass createRuntimeClass() {
 		RuntimeClassImpl runtimeClass = new RuntimeClassImpl();
 		return runtimeClass;
@@ -137,6 +140,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Method createMethod() {
 		MethodImpl method = new MethodImpl();
 		return method;
@@ -147,6 +151,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ModelUnit createModelUnit() {
 		ModelUnitImpl modelUnit = new ModelUnitImpl();
 		return modelUnit;
@@ -157,6 +162,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Attribute createAttribute() {
 		AttributeImpl attribute = new AttributeImpl();
 		return attribute;
@@ -167,6 +173,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Block createBlock() {
 		BlockImpl block = new BlockImpl();
 		return block;
@@ -177,6 +184,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Statement createStatement() {
 		StatementImpl statement = new StatementImpl();
 		return statement;
@@ -187,6 +195,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public VariableDeclaration createVariableDeclaration() {
 		VariableDeclarationImpl variableDeclaration = new VariableDeclarationImpl();
 		return variableDeclaration;
@@ -197,6 +206,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Assignment createAssignment() {
 		AssignmentImpl assignment = new AssignmentImpl();
 		return assignment;
@@ -207,6 +217,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public VariableAssignment createVariableAssignment() {
 		VariableAssignmentImpl variableAssignment = new VariableAssignmentImpl();
 		return variableAssignment;
@@ -217,6 +228,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FeatureAssignment createFeatureAssignment() {
 		FeatureAssignmentImpl featureAssignment = new FeatureAssignmentImpl();
 		return featureAssignment;
@@ -227,6 +239,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FeatureInsert createFeatureInsert() {
 		FeatureInsertImpl featureInsert = new FeatureInsertImpl();
 		return featureInsert;
@@ -237,6 +250,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FeatureRemove createFeatureRemove() {
 		FeatureRemoveImpl featureRemove = new FeatureRemoveImpl();
 		return featureRemove;
@@ -247,6 +261,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public VariableInsert createVariableInsert() {
 		VariableInsertImpl variableInsert = new VariableInsertImpl();
 		return variableInsert;
@@ -257,6 +272,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public VariableRemove createVariableRemove() {
 		VariableRemoveImpl variableRemove = new VariableRemoveImpl();
 		return variableRemove;
@@ -267,6 +283,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FeaturePut createFeaturePut() {
 		FeaturePutImpl featurePut = new FeaturePutImpl();
 		return featurePut;
@@ -277,6 +294,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ForEach createForEach() {
 		ForEachImpl forEach = new ForEachImpl();
 		return forEach;
@@ -287,6 +305,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public While createWhile() {
 		WhileImpl while_ = new WhileImpl();
 		return while_;
@@ -297,6 +316,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public If createIf() {
 		IfImpl if_ = new IfImpl();
 		return if_;
@@ -307,6 +327,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ConditionalBlock createConditionalBlock() {
 		ConditionalBlockImpl conditionalBlock = new ConditionalBlockImpl();
 		return conditionalBlock;
@@ -317,6 +338,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ExpressionStatement createExpressionStatement() {
 		ExpressionStatementImpl expressionStatement = new ExpressionStatementImpl();
 		return expressionStatement;
@@ -327,6 +349,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Switch createSwitch() {
 		SwitchImpl switch_ = new SwitchImpl();
 		return switch_;
@@ -337,6 +360,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Case createCase() {
 		CaseImpl case_ = new CaseImpl();
 		return case_;
@@ -347,6 +371,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public UnresolvedEClassifier createUnresolvedEClassifier() {
 		UnresolvedEClassifierImpl unresolvedEClassifier = new UnresolvedEClassifierImpl();
 		return unresolvedEClassifier;
@@ -357,6 +382,7 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ImplementationPackage getImplementationPackage() {
 		return (ImplementationPackage)getEPackage();
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationPackageImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationPackageImpl.java
@@ -316,6 +316,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getModelBehavior() {
 		return modelBehaviorEClass;
 	}
@@ -325,6 +326,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getModelBehavior_Name() {
 		return (EAttribute)modelBehaviorEClass.getEStructuralFeatures().get(0);
 	}
@@ -334,6 +336,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getModelBehavior_Units() {
 		return (EReference)modelBehaviorEClass.getEStructuralFeatures().get(1);
 	}
@@ -343,6 +346,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getExtendedClass() {
 		return extendedClassEClass;
 	}
@@ -352,6 +356,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getExtendedClass_BaseClass() {
 		return (EReference)extendedClassEClass.getEStructuralFeatures().get(0);
 	}
@@ -361,6 +366,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getExtendedClass_Extends() {
 		return (EReference)extendedClassEClass.getEStructuralFeatures().get(1);
 	}
@@ -370,6 +376,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getExtendedClass_Children() {
 		return (EReference)extendedClassEClass.getEStructuralFeatures().get(2);
 	}
@@ -379,6 +386,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getRuntimeClass() {
 		return runtimeClassEClass;
 	}
@@ -388,6 +396,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getMethod() {
 		return methodEClass;
 	}
@@ -397,6 +406,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getMethod_OperationRef() {
 		return (EReference)methodEClass.getEStructuralFeatures().get(0);
 	}
@@ -406,6 +416,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getMethod_Body() {
 		return (EReference)methodEClass.getEStructuralFeatures().get(1);
 	}
@@ -415,6 +426,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getMethod_Tags() {
 		return (EAttribute)methodEClass.getEStructuralFeatures().get(2);
 	}
@@ -424,6 +436,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getModelUnit() {
 		return modelUnitEClass;
 	}
@@ -433,6 +446,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getModelUnit_Services() {
 		return (EAttribute)modelUnitEClass.getEStructuralFeatures().get(0);
 	}
@@ -442,6 +456,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getModelUnit_ClassExtensions() {
 		return (EReference)modelUnitEClass.getEStructuralFeatures().get(1);
 	}
@@ -451,6 +466,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getModelUnit_ClassDefinitions() {
 		return (EReference)modelUnitEClass.getEStructuralFeatures().get(2);
 	}
@@ -460,6 +476,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getBehavioredClass() {
 		return behavioredClassEClass;
 	}
@@ -469,6 +486,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getBehavioredClass_Methods() {
 		return (EReference)behavioredClassEClass.getEStructuralFeatures().get(0);
 	}
@@ -478,6 +496,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getBehavioredClass_Attributes() {
 		return (EReference)behavioredClassEClass.getEStructuralFeatures().get(1);
 	}
@@ -487,6 +506,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getBehavioredClass_Fragment() {
 		return (EReference)behavioredClassEClass.getEStructuralFeatures().get(2);
 	}
@@ -496,6 +516,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getAttribute() {
 		return attributeEClass;
 	}
@@ -505,6 +526,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getAttribute_FeatureRef() {
 		return (EReference)attributeEClass.getEStructuralFeatures().get(0);
 	}
@@ -514,6 +536,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getAttribute_InitialValue() {
 		return (EReference)attributeEClass.getEStructuralFeatures().get(1);
 	}
@@ -523,6 +546,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getBlock() {
 		return blockEClass;
 	}
@@ -532,6 +556,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getBlock_Statements() {
 		return (EReference)blockEClass.getEStructuralFeatures().get(0);
 	}
@@ -541,6 +566,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStatement() {
 		return statementEClass;
 	}
@@ -550,6 +576,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getVariableDeclaration() {
 		return variableDeclarationEClass;
 	}
@@ -559,6 +586,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getVariableDeclaration_Name() {
 		return (EAttribute)variableDeclarationEClass.getEStructuralFeatures().get(0);
 	}
@@ -568,6 +596,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getVariableDeclaration_Type() {
 		return (EReference)variableDeclarationEClass.getEStructuralFeatures().get(1);
 	}
@@ -577,6 +606,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getVariableDeclaration_InitialValue() {
 		return (EReference)variableDeclarationEClass.getEStructuralFeatures().get(2);
 	}
@@ -586,15 +616,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EReference getVariableDeclaration_TypeParameter() {
-		return (EReference)variableDeclarationEClass.getEStructuralFeatures().get(3);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+	@Override
 	public EClass getAssignment() {
 		return assignmentEClass;
 	}
@@ -604,6 +626,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getAssignment_Value() {
 		return (EReference)assignmentEClass.getEStructuralFeatures().get(0);
 	}
@@ -613,6 +636,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getVariableAssignment() {
 		return variableAssignmentEClass;
 	}
@@ -622,6 +646,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getVariableAssignment_Name() {
 		return (EAttribute)variableAssignmentEClass.getEStructuralFeatures().get(0);
 	}
@@ -631,6 +656,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFeatureAssignment() {
 		return featureAssignmentEClass;
 	}
@@ -640,6 +666,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getFeatureAssignment_Target() {
 		return (EReference)featureAssignmentEClass.getEStructuralFeatures().get(0);
 	}
@@ -649,6 +676,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getFeatureAssignment_TargetFeature() {
 		return (EAttribute)featureAssignmentEClass.getEStructuralFeatures().get(1);
 	}
@@ -658,6 +686,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFeatureInsert() {
 		return featureInsertEClass;
 	}
@@ -667,6 +696,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getFeatureInsert_Target() {
 		return (EReference)featureInsertEClass.getEStructuralFeatures().get(0);
 	}
@@ -676,6 +706,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getFeatureInsert_TargetFeature() {
 		return (EAttribute)featureInsertEClass.getEStructuralFeatures().get(1);
 	}
@@ -685,6 +716,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFeatureRemove() {
 		return featureRemoveEClass;
 	}
@@ -694,6 +726,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getFeatureRemove_Target() {
 		return (EReference)featureRemoveEClass.getEStructuralFeatures().get(0);
 	}
@@ -703,6 +736,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getFeatureRemove_TargetFeature() {
 		return (EAttribute)featureRemoveEClass.getEStructuralFeatures().get(1);
 	}
@@ -712,6 +746,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getVariableInsert() {
 		return variableInsertEClass;
 	}
@@ -721,6 +756,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getVariableInsert_Name() {
 		return (EAttribute)variableInsertEClass.getEStructuralFeatures().get(0);
 	}
@@ -730,6 +766,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getVariableRemove() {
 		return variableRemoveEClass;
 	}
@@ -739,6 +776,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getVariableRemove_Name() {
 		return (EAttribute)variableRemoveEClass.getEStructuralFeatures().get(0);
 	}
@@ -748,6 +786,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFeaturePut() {
 		return featurePutEClass;
 	}
@@ -757,6 +796,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getFeaturePut_Target() {
 		return (EReference)featurePutEClass.getEStructuralFeatures().get(0);
 	}
@@ -766,6 +806,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getFeaturePut_TargetFeature() {
 		return (EAttribute)featurePutEClass.getEStructuralFeatures().get(1);
 	}
@@ -775,6 +816,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getFeaturePut_Key() {
 		return (EReference)featurePutEClass.getEStructuralFeatures().get(2);
 	}
@@ -784,6 +826,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getFeaturePut_Value() {
 		return (EReference)featurePutEClass.getEStructuralFeatures().get(3);
 	}
@@ -793,6 +836,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getForEach() {
 		return forEachEClass;
 	}
@@ -802,6 +846,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getForEach_Variable() {
 		return (EAttribute)forEachEClass.getEStructuralFeatures().get(0);
 	}
@@ -811,6 +856,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getForEach_CollectionExpression() {
 		return (EReference)forEachEClass.getEStructuralFeatures().get(1);
 	}
@@ -820,6 +866,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getForEach_Body() {
 		return (EReference)forEachEClass.getEStructuralFeatures().get(2);
 	}
@@ -829,6 +876,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getWhile() {
 		return whileEClass;
 	}
@@ -838,6 +886,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getWhile_Condition() {
 		return (EReference)whileEClass.getEStructuralFeatures().get(0);
 	}
@@ -847,6 +896,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getWhile_Body() {
 		return (EReference)whileEClass.getEStructuralFeatures().get(1);
 	}
@@ -856,6 +906,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getIf() {
 		return ifEClass;
 	}
@@ -865,6 +916,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getIf_Blocks() {
 		return (EReference)ifEClass.getEStructuralFeatures().get(0);
 	}
@@ -874,6 +926,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getIf_Else() {
 		return (EReference)ifEClass.getEStructuralFeatures().get(1);
 	}
@@ -883,6 +936,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getConditionalBlock() {
 		return conditionalBlockEClass;
 	}
@@ -892,6 +946,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getConditionalBlock_Condition() {
 		return (EReference)conditionalBlockEClass.getEStructuralFeatures().get(0);
 	}
@@ -901,6 +956,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getConditionalBlock_Block() {
 		return (EReference)conditionalBlockEClass.getEStructuralFeatures().get(1);
 	}
@@ -910,6 +966,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getExpressionStatement() {
 		return expressionStatementEClass;
 	}
@@ -919,6 +976,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getExpressionStatement_Expression() {
 		return (EReference)expressionStatementEClass.getEStructuralFeatures().get(0);
 	}
@@ -928,6 +986,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSwitch() {
 		return switchEClass;
 	}
@@ -937,6 +996,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getSwitch_Param() {
 		return (EReference)switchEClass.getEStructuralFeatures().get(0);
 	}
@@ -946,6 +1006,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getSwitch_Cases() {
 		return (EReference)switchEClass.getEStructuralFeatures().get(1);
 	}
@@ -955,6 +1016,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getSwitch_Default() {
 		return (EReference)switchEClass.getEStructuralFeatures().get(2);
 	}
@@ -964,6 +1026,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getCase() {
 		return caseEClass;
 	}
@@ -973,6 +1036,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getCase_Guard() {
 		return (EReference)caseEClass.getEStructuralFeatures().get(0);
 	}
@@ -982,6 +1046,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getCase_Match() {
 		return (EReference)caseEClass.getEStructuralFeatures().get(1);
 	}
@@ -991,6 +1056,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getCase_Value() {
 		return (EReference)caseEClass.getEStructuralFeatures().get(2);
 	}
@@ -1000,6 +1066,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getUnresolvedEClassifier() {
 		return unresolvedEClassifierEClass;
 	}
@@ -1009,6 +1076,7 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public ImplementationFactory getImplementationFactory() {
 		return (ImplementationFactory)getEFactoryInstance();
 	}
@@ -1071,7 +1139,6 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 		createEAttribute(variableDeclarationEClass, VARIABLE_DECLARATION__NAME);
 		createEReference(variableDeclarationEClass, VARIABLE_DECLARATION__TYPE);
 		createEReference(variableDeclarationEClass, VARIABLE_DECLARATION__INITIAL_VALUE);
-		createEReference(variableDeclarationEClass, VARIABLE_DECLARATION__TYPE_PARAMETER);
 
 		assignmentEClass = createEClass(ASSIGNMENT);
 		createEReference(assignmentEClass, ASSIGNMENT__VALUE);
@@ -1228,9 +1295,8 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 
 		initEClass(variableDeclarationEClass, VariableDeclaration.class, "VariableDeclaration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getVariableDeclaration_Name(), ecorePackage.getEString(), "name", null, 1, 1, VariableDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getVariableDeclaration_Type(), ecorePackage.getEClassifier(), null, "type", null, 1, 1, VariableDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getVariableDeclaration_Type(), ecorePackage.getETypedElement(), null, "type", null, 1, 1, VariableDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getVariableDeclaration_InitialValue(), theAstPackage.getExpression(), null, "initialValue", null, 0, 1, VariableDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getVariableDeclaration_TypeParameter(), ecorePackage.getEClassifier(), null, "typeParameter", null, 1, 1, VariableDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(assignmentEClass, Assignment.class, "Assignment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getAssignment_Value(), theAstPackage.getExpression(), null, "value", null, 1, 1, Assignment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/MethodImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/MethodImpl.java
@@ -108,6 +108,7 @@ public class MethodImpl extends MinimalEObjectImpl.Container implements Method {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EOperation getOperationRef() {
 		if (operationRef != null && operationRef.eIsProxy()) {
 			InternalEObject oldOperationRef = (InternalEObject)operationRef;
@@ -134,6 +135,7 @@ public class MethodImpl extends MinimalEObjectImpl.Container implements Method {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setOperationRef(EOperation newOperationRef) {
 		EOperation oldOperationRef = operationRef;
 		operationRef = newOperationRef;
@@ -146,6 +148,7 @@ public class MethodImpl extends MinimalEObjectImpl.Container implements Method {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Block getBody() {
 		return body;
 	}
@@ -170,6 +173,7 @@ public class MethodImpl extends MinimalEObjectImpl.Container implements Method {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setBody(Block newBody) {
 		if (newBody != body) {
 			NotificationChain msgs = null;
@@ -189,6 +193,7 @@ public class MethodImpl extends MinimalEObjectImpl.Container implements Method {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<String> getTags() {
 		if (tags == null) {
 			tags = new EDataTypeUniqueEList<String>(String.class, this, ImplementationPackage.METHOD__TAGS);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ModelBehaviorImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ModelBehaviorImpl.java
@@ -107,6 +107,7 @@ public class ModelBehaviorImpl extends MinimalEObjectImpl.Container implements M
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -116,6 +117,7 @@ public class ModelBehaviorImpl extends MinimalEObjectImpl.Container implements M
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setName(String newName) {
 		String oldName = name;
 		name = newName;
@@ -128,6 +130,7 @@ public class ModelBehaviorImpl extends MinimalEObjectImpl.Container implements M
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<ModelUnit> getUnits() {
 		if (units == null) {
 			units = new EObjectContainmentEList<ModelUnit>(ModelUnit.class, this, ImplementationPackage.MODEL_BEHAVIOR__UNITS);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ModelUnitImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ModelUnitImpl.java
@@ -106,6 +106,7 @@ public class ModelUnitImpl extends ENamedElementImpl implements ModelUnit {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<String> getServices() {
 		if (services == null) {
 			services = new EDataTypeUniqueEList<String>(String.class, this, ImplementationPackage.MODEL_UNIT__SERVICES);
@@ -118,6 +119,7 @@ public class ModelUnitImpl extends ENamedElementImpl implements ModelUnit {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<ExtendedClass> getClassExtensions() {
 		if (classExtensions == null) {
 			classExtensions = new EObjectContainmentEList<ExtendedClass>(ExtendedClass.class, this, ImplementationPackage.MODEL_UNIT__CLASS_EXTENSIONS);
@@ -130,6 +132,7 @@ public class ModelUnitImpl extends ENamedElementImpl implements ModelUnit {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<RuntimeClass> getClassDefinitions() {
 		if (classDefinitions == null) {
 			classDefinitions = new EObjectContainmentEList<RuntimeClass>(RuntimeClass.class, this, ImplementationPackage.MODEL_UNIT__CLASS_DEFINITIONS);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/SwitchImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/SwitchImpl.java
@@ -111,6 +111,7 @@ public class SwitchImpl extends ExpressionImpl implements Switch {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getParam() {
 		return param;
 	}
@@ -135,6 +136,7 @@ public class SwitchImpl extends ExpressionImpl implements Switch {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setParam(Expression newParam) {
 		if (newParam != param) {
 			NotificationChain msgs = null;
@@ -154,6 +156,7 @@ public class SwitchImpl extends ExpressionImpl implements Switch {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Case> getCases() {
 		if (cases == null) {
 			cases = new EObjectContainmentEList<Case>(Case.class, this, ImplementationPackage.SWITCH__CASES);
@@ -166,6 +169,7 @@ public class SwitchImpl extends ExpressionImpl implements Switch {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getDefault() {
 		return default_;
 	}
@@ -190,6 +194,7 @@ public class SwitchImpl extends ExpressionImpl implements Switch {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setDefault(Expression newDefault) {
 		if (newDefault != default_) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableAssignmentImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableAssignmentImpl.java
@@ -85,6 +85,7 @@ public class VariableAssignmentImpl extends AssignmentImpl implements VariableAs
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -94,6 +95,7 @@ public class VariableAssignmentImpl extends AssignmentImpl implements VariableAs
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setName(String newName) {
 		String oldName = name;
 		name = newName;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableDeclarationImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableDeclarationImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
@@ -36,7 +36,6 @@ import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
  *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.impl.VariableDeclarationImpl#getName <em>Name</em>}</li>
  *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.impl.VariableDeclarationImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.impl.VariableDeclarationImpl#getInitialValue <em>Initial Value</em>}</li>
- *   <li>{@link org.eclipse.emf.ecoretools.ale.implementation.impl.VariableDeclarationImpl#getTypeParameter <em>Type Parameter</em>}</li>
  * </ul>
  *
  * @generated
@@ -77,7 +76,7 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * @generated
 	 * @ordered
 	 */
-	protected EClassifier type;
+	protected ETypedElement type;
 
 	/**
 	 * The cached value of the '{@link #getInitialValue() <em>Initial Value</em>}' containment reference.
@@ -88,16 +87,6 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * @ordered
 	 */
 	protected Expression initialValue;
-
-	/**
-	 * The cached value of the '{@link #getTypeParameter() <em>Type Parameter</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getTypeParameter()
-	 * @generated
-	 * @ordered
-	 */
-	protected EClassifier typeParameter;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -123,6 +112,7 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -132,6 +122,7 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setName(String newName) {
 		String oldName = name;
 		name = newName;
@@ -144,10 +135,11 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EClassifier getType() {
+	@Override
+	public ETypedElement getType() {
 		if (type != null && type.eIsProxy()) {
 			InternalEObject oldType = (InternalEObject)type;
-			type = (EClassifier)eResolveProxy(oldType);
+			type = (ETypedElement)eResolveProxy(oldType);
 			if (type != oldType) {
 				if (eNotificationRequired())
 					eNotify(new ENotificationImpl(this, Notification.RESOLVE, ImplementationPackage.VARIABLE_DECLARATION__TYPE, oldType, type));
@@ -161,7 +153,7 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EClassifier basicGetType() {
+	public ETypedElement basicGetType() {
 		return type;
 	}
 
@@ -170,8 +162,9 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setType(EClassifier newType) {
-		EClassifier oldType = type;
+	@Override
+	public void setType(ETypedElement newType) {
+		ETypedElement oldType = type;
 		type = newType;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, ImplementationPackage.VARIABLE_DECLARATION__TYPE, oldType, type));
@@ -182,6 +175,7 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getInitialValue() {
 		return initialValue;
 	}
@@ -206,6 +200,7 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setInitialValue(Expression newInitialValue) {
 		if (newInitialValue != initialValue) {
 			NotificationChain msgs = null;
@@ -218,44 +213,6 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 		}
 		else if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, ImplementationPackage.VARIABLE_DECLARATION__INITIAL_VALUE, newInitialValue, newInitialValue));
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EClassifier getTypeParameter() {
-		if (typeParameter != null && typeParameter.eIsProxy()) {
-			InternalEObject oldTypeParameter = (InternalEObject)typeParameter;
-			typeParameter = (EClassifier)eResolveProxy(oldTypeParameter);
-			if (typeParameter != oldTypeParameter) {
-				if (eNotificationRequired())
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE, ImplementationPackage.VARIABLE_DECLARATION__TYPE_PARAMETER, oldTypeParameter, typeParameter));
-			}
-		}
-		return typeParameter;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EClassifier basicGetTypeParameter() {
-		return typeParameter;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public void setTypeParameter(EClassifier newTypeParameter) {
-		EClassifier oldTypeParameter = typeParameter;
-		typeParameter = newTypeParameter;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, ImplementationPackage.VARIABLE_DECLARATION__TYPE_PARAMETER, oldTypeParameter, typeParameter));
 	}
 
 	/**
@@ -287,9 +244,6 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 				return basicGetType();
 			case ImplementationPackage.VARIABLE_DECLARATION__INITIAL_VALUE:
 				return getInitialValue();
-			case ImplementationPackage.VARIABLE_DECLARATION__TYPE_PARAMETER:
-				if (resolve) return getTypeParameter();
-				return basicGetTypeParameter();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -306,13 +260,10 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 				setName((String)newValue);
 				return;
 			case ImplementationPackage.VARIABLE_DECLARATION__TYPE:
-				setType((EClassifier)newValue);
+				setType((ETypedElement)newValue);
 				return;
 			case ImplementationPackage.VARIABLE_DECLARATION__INITIAL_VALUE:
 				setInitialValue((Expression)newValue);
-				return;
-			case ImplementationPackage.VARIABLE_DECLARATION__TYPE_PARAMETER:
-				setTypeParameter((EClassifier)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -330,13 +281,10 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 				setName(NAME_EDEFAULT);
 				return;
 			case ImplementationPackage.VARIABLE_DECLARATION__TYPE:
-				setType((EClassifier)null);
+				setType((ETypedElement)null);
 				return;
 			case ImplementationPackage.VARIABLE_DECLARATION__INITIAL_VALUE:
 				setInitialValue((Expression)null);
-				return;
-			case ImplementationPackage.VARIABLE_DECLARATION__TYPE_PARAMETER:
-				setTypeParameter((EClassifier)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -356,8 +304,6 @@ public class VariableDeclarationImpl extends StatementImpl implements VariableDe
 				return type != null;
 			case ImplementationPackage.VARIABLE_DECLARATION__INITIAL_VALUE:
 				return initialValue != null;
-			case ImplementationPackage.VARIABLE_DECLARATION__TYPE_PARAMETER:
-				return typeParameter != null;
 		}
 		return super.eIsSet(featureID);
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableInsertImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableInsertImpl.java
@@ -85,6 +85,7 @@ public class VariableInsertImpl extends AssignmentImpl implements VariableInsert
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -94,6 +95,7 @@ public class VariableInsertImpl extends AssignmentImpl implements VariableInsert
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setName(String newName) {
 		String oldName = name;
 		name = newName;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableRemoveImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/VariableRemoveImpl.java
@@ -85,6 +85,7 @@ public class VariableRemoveImpl extends AssignmentImpl implements VariableRemove
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -94,6 +95,7 @@ public class VariableRemoveImpl extends AssignmentImpl implements VariableRemove
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setName(String newName) {
 		String oldName = name;
 		name = newName;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/WhileImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/WhileImpl.java
@@ -91,6 +91,7 @@ public class WhileImpl extends StatementImpl implements While {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Expression getCondition() {
 		return condition;
 	}
@@ -115,6 +116,7 @@ public class WhileImpl extends StatementImpl implements While {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setCondition(Expression newCondition) {
 		if (newCondition != condition) {
 			NotificationChain msgs = null;
@@ -134,6 +136,7 @@ public class WhileImpl extends StatementImpl implements While {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Block getBody() {
 		return body;
 	}
@@ -158,6 +161,7 @@ public class WhileImpl extends StatementImpl implements While {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setBody(Block newBody) {
 		if (newBody != body) {
 			NotificationChain msgs = null;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/MethodEvaluator.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Stack;
 
 import org.eclipse.acceleo.query.ast.Expression;
@@ -132,16 +133,16 @@ public class MethodEvaluator {
 	}
 	
 	private Optional<Object> defaultValueFor(VariableDeclaration varDecl) {
-		if (varDecl.getType() == EcorePackage.eINSTANCE.getEString()) {
-			return Optional.of("");
-		}
-		if (varDecl.getType() == EcorePackage.eINSTANCE.getEInt()) {
-			return Optional.of(0);
-		}
-		if (varDecl.getType() == EcorePackage.eINSTANCE.getEEList()) {
+		if (varDecl.getType().isMany()) {
 			return Optional.of(new BasicEList<>());
 		}
-		if (varDecl.getType() == EcorePackage.eINSTANCE.getEBoolean()) {
+		if (varDecl.getType().getEType() == EcorePackage.eINSTANCE.getEString()) {
+			return Optional.of("");
+		}
+		if (varDecl.getType().getEType() == EcorePackage.eINSTANCE.getEInt()) {
+			return Optional.of(0);
+		}
+		if (varDecl.getType().getEType() == EcorePackage.eINSTANCE.getEBoolean()) {
 			return Optional.of(false);
 		}
 		return Optional.empty();
@@ -170,8 +171,8 @@ public class MethodEvaluator {
 		if(assigned instanceof EObject){
 			EStructuralFeature feature = ((EObject)assigned).eClass().getEStructuralFeature(featAssign.getTargetFeature());
 			if(feature != null){
-				if(value instanceof List) {
-					BasicEList<EObject> newList = new BasicEList<>((List)value);
+				if(value instanceof Collection) {
+					BasicEList<EObject> newList = new BasicEList<>((Collection)value);
 					((EObject)assigned).eSet(feature, newList);
 				}
 				else {
@@ -224,12 +225,12 @@ public class MethodEvaluator {
 			Object insertedValue = aqlEval(varInsert.getValue());
 			Object variableValue = scope.get(varInsert.getName());
 			
-			if(variableValue instanceof List) {
-				if(insertedValue instanceof List) {
-					((List)variableValue).addAll((List) insertedValue);
+			if(variableValue instanceof Collection) {
+				if(insertedValue instanceof Collection) {
+					((Collection)variableValue).addAll((Collection) insertedValue);
 				}
 				else {
-					((List)variableValue).add(insertedValue);
+					((Collection)variableValue).add(insertedValue);
 				}
 			}
 			else if(variableValue instanceof String) {
@@ -260,12 +261,12 @@ public class MethodEvaluator {
 			Object insertedValue = aqlEval(varInsert.getValue());
 			Object variableValue = scope.get(varInsert.getName());
 			
-			if(variableValue instanceof List) {
-				if(insertedValue instanceof List) {
-					((List)variableValue).removeAll((List) insertedValue);
+			if(variableValue instanceof Collection) {
+				if(insertedValue instanceof Collection) {
+					((Collection)variableValue).removeAll((Collection) insertedValue);
 				}
 				else {
-					((List)variableValue).remove(insertedValue);
+					((Collection)variableValue).remove(insertedValue);
 				}
 			}
 			else if(variableValue instanceof Integer && insertedValue instanceof Integer) {
@@ -298,12 +299,12 @@ public class MethodEvaluator {
 			try {
 				if(feature != null){
 					Object featureValue = ((EObject)assigned).eGet(feature);
-					if(featureValue instanceof EList){
+					if(featureValue instanceof Collection){
 						if (value instanceof Collection) {
-							((EList)featureValue).addAll((Collection) value);
+							((Collection)featureValue).addAll((Collection) value);
 						}
 						else {
-							((EList)featureValue).add(value);
+							((Collection)featureValue).add(value);
 						}
 					}
 				}
@@ -333,8 +334,13 @@ public class MethodEvaluator {
 			EStructuralFeature feature = ((EObject)assigned).eClass().getEStructuralFeature(featRemove.getTargetFeature());
 			if(feature != null){
 				Object featureValue = ((EObject)assigned).eGet(feature);
-				if(featureValue instanceof EList){
-					((EList)featureValue).remove(value);
+				if(featureValue instanceof Collection){
+					if (value instanceof Collection) {
+						((Collection)featureValue).removeAll((Collection) value);
+					}
+					else {
+						((Collection)featureValue).remove(value);
+					}
 				}
 			}
 			else {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/visitor/ModelBuilder.java
@@ -276,15 +276,8 @@ public class ModelBuilder {
 			varDecl.setInitialValue(parseExp(exp,parseRes));
 		}
 		ETypedElement declaredType = resolve(type);
-		varDecl.setType(declaredType.getEType());
+		varDecl.setType(declaredType);
 		
-		// FIXME This is a hack: declaration should have bounds and isUnique such as Attribute
-		//		 Currently we can't represent Sets and nested Lists
-		
-		if(declaredType.isMany()) {
-			varDecl.setType(EcorePackage.eINSTANCE.getEEList());
-			varDecl.setTypeParameter(resolveParameterType(type));
-		}
 		return varDecl;
 	}
 	

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/BaseValidator.java
@@ -400,7 +400,7 @@ public class BaseValidator extends ImplementationSwitch<Object> {
 			lastScope.put(varDecl.getName(), getPossibleTypes(varDecl.getInitialValue()));
 		}
 		else {
-			EClassifierType declaredType = new EClassifierType(qryEnv, varDecl.getType());
+			IType declaredType = convert.toAQL(varDecl.getType());
 			lastScope.put(varDecl.getName(), Sets.newHashSet(declaredType));
 		}
 		

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
@@ -137,7 +137,7 @@ public interface ITypeChecker {
 	 * <p>
 	 * This method performs checks corresponding to the previous cases then calls {@link IType#isAssignableFrom(IType)}.
 	 * 
-	 * @param variable
+	 * @param variableType
 	 * 			The type to which a value should be assigned
 	 * @param valueType
 	 * 			The type of the expression to assign
@@ -208,9 +208,29 @@ public interface ITypeChecker {
 	 * @param type
 	 * 			The type to check
 	 * 
-	 * @return true if the type represents {@code null}
+	 * @return true if the type represents {@code null}, false otherwise
 	 */
 	boolean isNull(IType type);
+
+	/**
+	 * Determines whether the given type corresponds to a set of unique elements.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type represents a set, false otherwise
+	 */
+	boolean isSet(IType type);
+
+	/**
+	 * Determines whether the given type corresponds to an ordered list.
+	 * 
+	 * @param type
+	 * 			The type to check
+	 * 
+	 * @return true if the type represents an ordered list, false otherwise
+	 */
+	boolean isSequence(IType type);
 	
 	/**
 	 * Determines whether the given type corresponds to a string.

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/ITypeChecker.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 import org.eclipse.acceleo.query.ast.Expression;
 import org.eclipse.acceleo.query.validation.type.IType;
-import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.ETypedElement;
 
 /**
  * Used to check properties about types manipulated by ALE.
@@ -240,7 +240,7 @@ public interface ITypeChecker {
 	 * 
 	 * @return false is the type has been resolved, true otherwise
 	 */
-	boolean isUnresolved(EClassifier type);
+	boolean isUnresolved(ETypedElement type);
 	
 	/**
 	 * Determines whether a type supports the '+=' operator.

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/QualifiedNames.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/QualifiedNames.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import org.eclipse.acceleo.query.validation.type.AbstractCollectionType;
 import org.eclipse.acceleo.query.validation.type.EClassifierType;
 import org.eclipse.acceleo.query.validation.type.IType;
+import org.eclipse.acceleo.query.validation.type.SequenceType;
 import org.eclipse.acceleo.query.validation.type.SetType;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EPackage;
@@ -55,6 +56,10 @@ final public class QualifiedNames {
 		if(type instanceof SetType) {
 			AbstractCollectionType collectionType = (AbstractCollectionType) type;
 			return "Set(" + getQualifiedName(collectionType.getCollectionType()) + ")";
+		}
+		if(type instanceof SequenceType) {
+			AbstractCollectionType collectionType = (AbstractCollectionType) type;
+			return "Sequence(" + getQualifiedName(collectionType.getCollectionType()) + ")";
 		}
 		if(type instanceof AbstractCollectionType) {
 			AbstractCollectionType collectionType = (AbstractCollectionType) type;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -148,7 +148,7 @@ public class TypeValidator implements IValidator {
 		// Check whether the types of the attributes can be resolved
 		
 		clazz.getAttributes().stream()
-		.filter(att -> typeChecker.isUnresolved(att.getFeatureRef().getEType()))
+		.filter(att -> typeChecker.isUnresolved(att.getFeatureRef()))
 		.map(messages::unresolvedType)
 		.forEach(msgs::add);
 		
@@ -314,7 +314,7 @@ public class TypeValidator implements IValidator {
 			// Nothing to validate: no initial value => a default one will be used instead.
 			return NO_PROBLEM;
 		}
-		IType variableType = convert.toAQL(varDecl.getType(), varDecl.getTypeParameter());
+		IType variableType = convert.toAQL(varDecl.getType());
 		Set<IType> valueTypes = lookup.inferredTypesOf(varDecl.getInitialValue());
 		
 		boolean initialValueCanBeAssigned = typeChecker.isAssignable(variableType, valueTypes);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -322,7 +322,7 @@ public class TypeValidator implements IValidator {
 			return NO_PROBLEM;
 		}
 		else {
-			IValidationMessage incompatibleTypes = messages.incompatibleTypes(newHashSet(variableType), valueTypes, varDecl);
+			IValidationMessage incompatibleTypes = messages.illegalAssignment(newHashSet(variableType), valueTypes, varDecl);
 			return asList(incompatibleTypes);
 		}
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
 import org.eclipse.emf.ecoretools.ale.core.validation.IAstLookup;
 import org.eclipse.emf.ecoretools.ale.core.validation.IConvertType;
@@ -84,9 +85,8 @@ public final class AstLookup implements IAstLookup {
 						.filter(varDecl -> varDecl.getName().equals(variableName))
 						.findFirst();
 					if(candidate.isPresent()) {
-						EClassifier type = candidate.get().getType();
-						EClassifier typeParameter = candidate.get().getTypeParameter();
-						declaredTypes.add(convert.toAQL(type, typeParameter));
+						ETypedElement type = candidate.get().getType();
+						declaredTypes.add(convert.toAQL(type));
 						return declaredTypes;
 					}
 				}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
@@ -24,6 +24,7 @@ import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EParameter;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
@@ -126,6 +127,19 @@ public final class AstLookup implements IAstLookup {
 					EClassifier type = feature.get().getEType();
 					declaredTypes.add(convert.toAQL(type));
 					return declaredTypes;
+				}
+			}
+			
+			// Look at enclosing method's parameters
+			else if (currentScope instanceof Method) {
+				Method method = (Method) currentScope;
+				Optional<EParameter> parameter = method.getOperationRef()
+													   .getEParameters().stream()
+													   .filter(param -> param.getName().equals(variableName))
+													   .findFirst();
+				
+				if (parameter.isPresent()) {
+					declaredTypes.add(convert.toAQL(parameter.get()));
 				}
 			}
 			currentObject = currentScope;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
@@ -23,6 +23,7 @@ import org.eclipse.acceleo.query.validation.type.EClassifierType;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.acceleo.query.validation.type.NothingType;
 import org.eclipse.acceleo.query.validation.type.SequenceType;
+import org.eclipse.acceleo.query.validation.type.SetType;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EGenericType;
@@ -51,15 +52,13 @@ public final class ConvertType implements IConvertType {
 			return new SequenceType(queryEnvironment, aqlGenericType);
 		}
 		else {
-//			EStructuralFeature feature = (EStructuralFeature) typedElement;
 			if(typedElement.isMany()) {
-				// FIXME Unique is true by default so currently any feature is turned into a set; we should set it to false
-//				if(feature.isUnique()) {
-//					return new SetType(env, TypeConverter.toAQL(env, feature.getEType()));
-//				}
-//				else {
+				if(typedElement.isUnique()) {
+					return new SetType(queryEnvironment, toAQL(typedElement.getEType()));
+				}
+				else {
 					return new SequenceType(queryEnvironment, toAQL(typedElement.getEType()));
-//				}
+				}
 			}
 		}
 		return toAQL(typedElement.getEType());

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
@@ -21,8 +21,9 @@ import org.eclipse.acceleo.query.validation.type.ClassType;
 import org.eclipse.acceleo.query.validation.type.ICollectionType;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.acceleo.query.validation.type.NothingType;
-import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecoretools.ale.core.validation.BaseValidator;
 import org.eclipse.emf.ecoretools.ale.core.validation.ITypeChecker;
@@ -96,8 +97,8 @@ public final class TypeChecker implements ITypeChecker {
 				if(isCollection(variableType) && isCollection(valueType) && isAssignable(variableType, valueType)) {
 					// collections concatenation
 					return true;
-				}
 			}
+		}
 		}
 		return false;
 	}
@@ -259,8 +260,8 @@ public final class TypeChecker implements ITypeChecker {
 	}
 	
 	@Override
-	public boolean isUnresolved(EClassifier type) {
-		return type == ImplementationPackage.eINSTANCE.getUnresolvedEClassifier();
+	public boolean isUnresolved(ETypedElement type) {
+		return type.getEType() == ImplementationPackage.eINSTANCE.getUnresolvedEClassifier();
 	}
 
 	@Override

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/TypeChecker.java
@@ -21,7 +21,8 @@ import org.eclipse.acceleo.query.validation.type.ClassType;
 import org.eclipse.acceleo.query.validation.type.ICollectionType;
 import org.eclipse.acceleo.query.validation.type.IType;
 import org.eclipse.acceleo.query.validation.type.NothingType;
-import org.eclipse.emf.ecore.EClass;
+import org.eclipse.acceleo.query.validation.type.SequenceType;
+import org.eclipse.acceleo.query.validation.type.SetType;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcorePackage;
@@ -90,15 +91,17 @@ public final class TypeChecker implements ITypeChecker {
 					// string concatenation
 					return true;
 				}
+				if(isCollection(variableType) && isCollection(valueType)) {
+					ICollectionType absorbingCollection = (ICollectionType) variableType;
+					ICollectionType absorbedCollection = (ICollectionType) valueType;
+					// collections concatenation
+					return elementCanBelongToCollection(absorbingCollection, absorbedCollection.getCollectionType());  
+				}
 				if(isCollection(variableType) && elementCanBelongToCollection(variableType, valueType)) {
 					// addition of an element to a collection
 					return true;
 				}
-				if(isCollection(variableType) && isCollection(valueType) && isAssignable(variableType, valueType)) {
-					// collections concatenation
-					return true;
 			}
-		}
 		}
 		return false;
 	}
@@ -111,12 +114,14 @@ public final class TypeChecker implements ITypeChecker {
 					// subtraction
 					return true;
 				}
+				if(isCollection(variableType) && isCollection(valueType)) {
+					ICollectionType absorbingCollection = (ICollectionType) variableType;
+					ICollectionType absorbedCollection = (ICollectionType) valueType;
+					// collections difference
+					return elementCanBelongToCollection(absorbingCollection, absorbedCollection.getCollectionType());  
+				}
 				if(isCollection(variableType) && elementCanBelongToCollection(variableType, valueType)) {
 					// removing an element from a collection
-					return true;
-				}
-				if(isCollection(variableType) && isCollection(valueType) && isAssignable(variableType, valueType)) {
-					// collections difference
 					return true;
 				}
 			}
@@ -152,17 +157,19 @@ public final class TypeChecker implements ITypeChecker {
 		if (isNull(valueType)) {
 			return true;
 		}
-		boolean bothAreCollections = isCollection(variableType) && isCollection(valueType);
-		if(bothAreCollections) {
+		if (isSet(variableType) && isSet(valueType)) {
 			return collectionsHaveCompatibleGenericTypes(variableType, valueType);
 		}
-		if(isBoolean(variableType) && isBoolean(valueType)) {
+		if (isSequence(variableType) && isSequence(valueType)) {
+			return collectionsHaveCompatibleGenericTypes(variableType, valueType);
+		}
+		if (isBoolean(variableType) && isBoolean(valueType)) {
 			return true;
 		}
-		if(isInteger(variableType) && isInteger(valueType)) {
+		if (isInteger(variableType) && isInteger(valueType)) {
 			return true;
 		}
-		if(isString(variableType) && isString(valueType)) {
+		if (isString(variableType) && isString(valueType)) {
 			return true;
 		}
 		return variableType.isAssignableFrom(valueType);
@@ -234,6 +241,16 @@ public final class TypeChecker implements ITypeChecker {
 			return true;
 		}
 		return false;
+	}
+	
+	@Override
+	public boolean isSet(IType type) {
+		return type instanceof SetType;
+	}
+	
+	@Override
+	public boolean isSequence(IType type) {
+		return type instanceof SequenceType;
 	}
 	
 	@Override

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/initLocalVariables.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/initLocalVariables.implem
@@ -8,10 +8,12 @@ open class Mix {
 		Boolean localBool;
 		String localString;
 		Sequence(String) localStrings;
+		OrderedSet(Integer) localIntegers;
 		
 		self.int := localInt;
 		self.bool := localBool;
 		self.string := localString;
 		self.strings := localStrings;
+		self.integers := localIntegers;
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/insertOrderedSet.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/insertOrderedSet.implem
@@ -1,0 +1,13 @@
+behavior test.containattributes;
+
+open class Mix {
+
+	@main
+	def void main() {
+		OrderedSet(Integer) localIntegers;
+		localIntegers += OrderedSet{1, 2, 3};
+		localIntegers += Sequence{4, 5, 5, 6, 4};
+		
+		self.integers += localIntegers;
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/removeOrderedSet.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/eval/removeOrderedSet.implem
@@ -1,0 +1,13 @@
+behavior test.containattributes;
+
+open class Mix {
+
+	@main
+	def void main() {
+		OrderedSet(Integer) localIntegers := OrderedSet{1, 2, 3, 4, 5, 6, 7};
+		localIntegers -= OrderedSet{1, 3, 5};
+
+		self.integers := localIntegers;
+		self.integers -= Sequence{6, 7};
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/additionAssignmentSequenceAndOrderedSet.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/additionAssignmentSequenceAndOrderedSet.implem
@@ -1,0 +1,23 @@
+behavior additionAssign;
+
+open class EClass {
+
+	Sequence(Boolean) sequenceFeature; 
+	OrderedSet(ecore::EClass) setFeature; 
+
+	def void main(Sequence(String) sequenceParameter, OrderedSet(Integer) setParameter) {
+		
+		self.sequenceFeature += OrderedSet{true, false, true};
+		self.setFeature += Sequence{self, ecore::EClass.create()};
+	
+		Sequence(Boolean) sequenceVariable; 
+		OrderedSet(ecore::EClass) setVariable;
+		
+		sequenceVariable += OrderedSet{true, false, true};
+		setVariable += Sequence{self, ecore::EClass.create()};
+
+		sequenceParameter += OrderedSet{'one', 'two'};
+		setParameter += Sequence{1, 2, 3};
+	}
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/additionAssignmentSequenceAndOrderedSetError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/additionAssignmentSequenceAndOrderedSetError.implem
@@ -1,0 +1,23 @@
+behavior additionAssign;
+
+open class EClass {
+
+	Sequence(Boolean) sequenceFeature; 
+	OrderedSet(ecore::EClass) setFeature; 
+
+	def void main(Sequence(String) sequenceParameter, OrderedSet(Integer) setParameter) {
+		
+		self.sequenceFeature += OrderedSet{1, 0, 1};
+		self.setFeature += Sequence{'one', 'two'};
+	
+		Sequence(Boolean) sequenceVariable; 
+		OrderedSet(ecore::EClass) setVariable;
+		
+		sequenceVariable += OrderedSet{1, 0, 1};
+		setVariable += Sequence{'one', 'two'};
+
+		sequenceParameter += OrderedSet{1, 2, 3};
+		setParameter += Sequence{true, false, true};
+	}
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignCollection.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignCollection.implem
@@ -1,6 +1,6 @@
 behavior test.assigncollection;
 open class EClass {
 	def void op(){
-		self.eSuperTypes := Sequence{self};
+		self.eSuperTypes := OrderedSet{self};
 	}
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignmentSequenceAndOrderedSetError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignmentSequenceAndOrderedSetError.implem
@@ -1,0 +1,8 @@
+behavior additionAssign;
+
+open class EClass {
+
+	Sequence(Boolean) sequenceFeature := OrderedSet{true, false}; 
+	OrderedSet(ecore::EClass) setFeature := Sequence{ecore::EClass.create(), ecore::EClass.create()}; 
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/substractionAssignmentSequenceAndOrderedSet.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/substractionAssignmentSequenceAndOrderedSet.implem
@@ -1,0 +1,23 @@
+behavior additionAssign;
+
+open class EClass {
+
+	Sequence(Boolean) sequenceFeature; 
+	OrderedSet(ecore::EClass) setFeature; 
+
+	def void main(Sequence(String) sequenceParameter, OrderedSet(Integer) setParameter) {
+		
+		self.sequenceFeature -= OrderedSet{true, false, true};
+		self.setFeature -= Sequence{self, ecore::EClass.create()};
+	
+		Sequence(Boolean) sequenceVariable; 
+		OrderedSet(ecore::EClass) setVariable;
+		
+		sequenceVariable -= OrderedSet{true, false, true};
+		setVariable -= Sequence{self, ecore::EClass.create()};
+
+		sequenceParameter -= OrderedSet{'one', 'two'};
+		setParameter -= Sequence{1, 2, 3};
+	}
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/substractionAssignmentSequenceAndOrderedSetError.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/substractionAssignmentSequenceAndOrderedSetError.implem
@@ -1,0 +1,23 @@
+behavior additionAssign;
+
+open class EClass {
+
+	Sequence(Boolean) sequenceFeature; 
+	OrderedSet(ecore::EClass) setFeature; 
+
+	def void main(Sequence(String) sequenceParameter, OrderedSet(Integer) setParameter) {
+		
+		self.sequenceFeature -= OrderedSet{1, 0, 1};
+		self.setFeature -= Sequence{'one', 'two'};
+	
+		Sequence(Boolean) sequenceVariable; 
+		OrderedSet(ecore::EClass) setVariable;
+		
+		sequenceVariable -= OrderedSet{1, 0, 1};
+		setVariable -= Sequence{'one', 'two'};
+
+		sequenceParameter -= OrderedSet{1, 2, 3};
+		setParameter -= Sequence{true, false, true};
+	}
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/model/attributesOfDifferentTypes.ecore
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/model/attributesOfDifferentTypes.ecore
@@ -8,8 +8,9 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="bool" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
         defaultValueLiteral="false"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="string" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-        defaultValueLiteral="some sentence"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="strings" upperBound="-1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="strings" unique="false"
+        upperBound="-1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="integers" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"
+        upperBound="-1"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.emf.ecoretools.ale.core.interpreter.test;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -1040,6 +1041,7 @@ public class EvalTest {
 		assertEquals("bool should be initialized to false", false, caller.eGet(caller.eClass().getEStructuralFeature("bool")));
 		assertEquals("string should be initialized to an empty string", "", caller.eGet(caller.eClass().getEStructuralFeature("string")));
 		assertEquals("sequence should be initialized to an empty sequence", new BasicEList<>(), caller.eGet(caller.eClass().getEStructuralFeature("strings")));
+		assertEquals("set should be initialized to an empty set", new BasicEList<>(), caller.eGet(caller.eClass().getEStructuralFeature("integers")));
 	}
 
 	@Test
@@ -1437,6 +1439,32 @@ public class EvalTest {
 
 		assertEquals("Cannot add the value to 'localNumbers': types mismatch", res.getDiagnostic().getMessage());
 		assertEquals(Diagnostic.ERROR, res.getDiagnostic().getSeverity());
+	}
+	
+	@Test
+	public void testInsertSequence() throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"), Arrays.asList("input/eval/insertOrderedSet.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		Method main = semantics.getMainMethods().get(0);
+		interpreter.eval(caller, main, Arrays.asList(), semantics);
+		
+		assertEquals("+= sould allow to concatenate sets with sets and sequences", asList(1, 2, 3, 4, 5, 6), caller.eGet(caller.eClass().getEStructuralFeature("integers")));
+	}
+	
+	@Test
+	public void testRemoveSequence() throws ClosedALEInterpreterException {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList("model/attributesOfDifferentTypes.ecore"), Arrays.asList("input/eval/removeOrderedSet.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment()))
+				.parse(environment);
+		EObject caller = interpreter.loadModel("model/Mix.xmi").getContents().get(0);
+		DslSemantics semantics = new ImmutableDslSemantics(parsedSemantics);
+		Method main = semantics.getMainMethods().get(0);
+		interpreter.eval(caller, main, Arrays.asList(), semantics);
+		
+		assertEquals("-= sould allow to substract sets with sets and sequences", asList(2, 4), caller.eGet(caller.eClass().getEStructuralFeature("integers")));
 	}
 	
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/parser/test/BuildTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/parser/test/BuildTest.java
@@ -41,6 +41,7 @@ import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.IAleEnvironment;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.impl.RuntimeAleEnvironment;
@@ -161,11 +162,11 @@ public class BuildTest {
 		Statement local1 = body.getStatements().get(1);
 		assertTrue(local0 instanceof VariableDeclaration);
 		assertEquals("localVariable",((VariableDeclaration)local0).getName());
-		assertEquals(EcorePackage.eINSTANCE.getEBoolean(),((VariableDeclaration)local0).getType());
+		assertEquals(EcorePackage.eINSTANCE.getEBoolean(),((VariableDeclaration)local0).getType().getEType());
 		assertNull(((VariableDeclaration)local0).getInitialValue());
 		assertTrue(local1 instanceof VariableDeclaration);
 		assertEquals("loacalValue",((VariableDeclaration)local1).getName());
-		assertEquals(EcorePackage.eINSTANCE.getEDouble(),((VariableDeclaration)local1).getType());
+		assertEquals(EcorePackage.eINSTANCE.getEDouble(),((VariableDeclaration)local1).getType().getEType());
 		assertNotNull(((VariableDeclaration)local1).getInitialValue());
 		Expression value = ((VariableDeclaration)local1).getInitialValue();
 		assertTrue(value instanceof Call);
@@ -249,7 +250,7 @@ public class BuildTest {
 		Statement local0 = body.getStatements().get(0);
 		assertTrue(local0 instanceof VariableDeclaration);
 		assertEquals("me",((VariableDeclaration)local0).getName());
-		assertEquals(EcorePackage.eINSTANCE.getEPackage(),((VariableDeclaration)local0).getType());
+		assertEquals(EcorePackage.eINSTANCE.getEPackage(),((VariableDeclaration)local0).getType().getEType());
 		Expression value = ((VariableDeclaration)local0).getInitialValue();
 		assertNotNull(value);
 		assertTrue(value instanceof VarRef);
@@ -272,7 +273,7 @@ public class BuildTest {
 		Statement stmt = loop1Body.getStatements().get(0);
 		assertTrue(stmt instanceof VariableDeclaration);
 		assertEquals("o",((VariableDeclaration)stmt).getName());
-		assertEquals(EcorePackage.eINSTANCE.getEObject(),((VariableDeclaration)stmt).getType());
+		assertEquals(EcorePackage.eINSTANCE.getEObject(),((VariableDeclaration)stmt).getType().getEType());
 		Expression stmtValue = ((VariableDeclaration)stmt).getInitialValue();
 		assertNotNull(stmtValue);
 		assertTrue(stmtValue instanceof Call);
@@ -401,7 +402,7 @@ public class BuildTest {
 		assertTrue(stmt1 instanceof VariableDeclaration);
 		VariableDeclaration var = (VariableDeclaration) stmt1;
 		assertEquals("i", var.getName());
-		assertEquals(EcorePackage.eINSTANCE.getEInt(), var.getType());
+		assertEquals(EcorePackage.eINSTANCE.getEInt(), var.getType().getEType());
 		assertNotNull(var.getInitialValue());
 		Expression value = var.getInitialValue();
 		assertTrue(value instanceof IntegerLiteral);
@@ -470,7 +471,7 @@ public class BuildTest {
 		Statement local0 = body.getStatements().get(0);
 		assertTrue(local0 instanceof VariableDeclaration);
 		assertEquals("me",((VariableDeclaration)local0).getName());
-		assertEquals(EcorePackage.eINSTANCE.getEPackage(),((VariableDeclaration)local0).getType());
+		assertEquals(EcorePackage.eINSTANCE.getEPackage(),((VariableDeclaration)local0).getType().getEType());
 		Expression value = ((VariableDeclaration)local0).getInitialValue();
 		assertNotNull(value);
 		assertTrue(value instanceof VarRef);
@@ -480,7 +481,7 @@ public class BuildTest {
 		assertTrue(stmt1 instanceof VariableDeclaration);
 		VariableDeclaration var = (VariableDeclaration) stmt1;
 		assertEquals("i", var.getName());
-		assertEquals(EcorePackage.eINSTANCE.getEInt(), var.getType());
+		assertEquals(EcorePackage.eINSTANCE.getEInt(), var.getType().getEType());
 		assertNotNull(var.getInitialValue());
 		Expression value1 = var.getInitialValue();
 		assertTrue(value1 instanceof IntegerLiteral);
@@ -892,7 +893,10 @@ public class BuildTest {
 		
 		Statement localDeclaration = body.getStatements().get(0);
 		assertTrue(localDeclaration instanceof VariableDeclaration);
-		assertEquals(EcorePackage.eINSTANCE.getEEList(), ((VariableDeclaration)localDeclaration).getType());
+		ETypedElement localDeclarationType = ((VariableDeclaration)localDeclaration).getType();
+		assertEquals(0, localDeclarationType.getLowerBound());
+		assertEquals(-1, localDeclarationType.getUpperBound());
+		assertEquals(EcorePackage.eINSTANCE.getEObject(), localDeclarationType.getEType());
 		assertEquals("local",((VariableDeclaration)localDeclaration).getName());
 		assertTrue(((VariableDeclaration)localDeclaration).getInitialValue() instanceof SequenceInExtensionLiteral);
 		assertEquals(0, ((SequenceInExtensionLiteral)((VariableDeclaration)localDeclaration).getInitialValue()).getValues().size());
@@ -932,7 +936,10 @@ public class BuildTest {
 		
 		Statement localDeclaration = body.getStatements().get(0);
 		assertTrue(localDeclaration instanceof VariableDeclaration);
-		assertEquals(EcorePackage.eINSTANCE.getEEList(), ((VariableDeclaration)localDeclaration).getType());
+		ETypedElement localDeclarationType = ((VariableDeclaration)localDeclaration).getType();
+		assertEquals(0, localDeclarationType.getLowerBound());
+		assertEquals(-1, localDeclarationType.getUpperBound());
+		assertEquals(EcorePackage.eINSTANCE.getEObject(), localDeclarationType.getEType());
 		assertEquals("local",((VariableDeclaration)localDeclaration).getName());
 		assertTrue(((VariableDeclaration)localDeclaration).getInitialValue() instanceof SequenceInExtensionLiteral);
 		assertEquals(1, ((SequenceInExtensionLiteral)((VariableDeclaration)localDeclaration).getInitialValue()).getValues().size());

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -220,7 +220,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 73, 90, "Expected [ecore::EString] but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 73, 90, "Type mismatch: cannot assign [java.lang.Integer] to [ecore::EString]", msg.get(0));
 	}
 	
 	/*
@@ -583,7 +583,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 103, 108, "[java.lang.String] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 103, 108, "[java.lang.String] cannot be added to [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])", msg.get(0));
 	}
 	
 	/*
@@ -616,7 +616,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 106, 111, "[java.lang.String] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 106, 111, "[java.lang.String] cannot be added to [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])", msg.get(0));
 	}
 	
 	/*
@@ -781,7 +781,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 103, 108, "[java.lang.String] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 103, 108, "[java.lang.String] cannot be removed from [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])", msg.get(0));
 	}
 	
 	/*
@@ -813,7 +813,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 106, 111, "[java.lang.String] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 106, 111, "[java.lang.String] cannot be removed from [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])", msg.get(0));
 	}
 	
 	/**
@@ -860,9 +860,9 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(3, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 177, 178, "[java.lang.Integer] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 193, 201, "[Collection(java.lang.Integer)] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 216, 230, "[Collection(java.lang.Integer)] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 177, 178, "[java.lang.Integer] cannot be added to [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 193, 201, "[Sequence(java.lang.Integer)] cannot be added to [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 216, 230, "[Sequence(java.lang.Integer)] cannot be added to [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(2));
 	}
 	
 	/**
@@ -893,8 +893,8 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(2, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 244, 250, "[java.lang.Integer] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 267, 273, "[java.lang.Integer] cannot be added to [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 244, 250, "[java.lang.Integer] cannot be added to [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 267, 273, "[java.lang.Integer] cannot be added to [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])", msg.get(1));
 	}
 	
 	/**
@@ -943,8 +943,8 @@ public class TypeValidatorTest {
 		assertEquals(4, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 75, 77, "[java.lang.Integer] cannot be added to [ecore::EString] (expected [ecore::EString])", msg.get(0));
 		assertMsgEquals(ValidationMessageLevel.ERROR, 111, 117, "[ecore::EBoolean] does not support the '+=' operator", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 179, 187, "[java.lang.String] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(2));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 201, 222, "[Collection(java.lang.Boolean)] cannot be added to [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 179, 187, "[java.lang.String] cannot be added to [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 201, 222, "[Sequence(java.lang.Boolean)] cannot be added to [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(3));
 	}
 	
 	/**
@@ -977,8 +977,8 @@ public class TypeValidatorTest {
 		assertEquals(4, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 75, 79, "[java.lang.String] cannot be removed from [ecore::EInt] (expected [ecore::EInt])", msg.get(0));
 		assertMsgEquals(ValidationMessageLevel.ERROR, 113, 119, "[ecore::EBoolean] does not support the '-=' operator", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 181, 189, "[java.lang.String] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(2));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 203, 224, "[Collection(java.lang.Boolean)] cannot be removed from [Collection(ecore::EInt)] (expected [Collection(ecore::EInt),ecore::EInt])", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 181, 189, "[java.lang.String] cannot be removed from [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 203, 224, "[Sequence(java.lang.Boolean)] cannot be removed from [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(3));
 	}
 	
 	@Test
@@ -1075,9 +1075,9 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(3, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 177, 178, "[java.lang.Integer] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 193, 201, "[Collection(java.lang.Integer)] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 216, 230, "[Collection(java.lang.Integer)] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 177, 178, "[java.lang.Integer] cannot be removed from [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 193, 201, "[Sequence(java.lang.Integer)] cannot be removed from [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 216, 230, "[Sequence(java.lang.Integer)] cannot be removed from [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(2));
 	}
 	
 	/**
@@ -1108,8 +1108,8 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(2, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 244, 250, "[java.lang.Integer] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 267, 273, "[java.lang.Integer] cannot be removed from [Collection(ecore::EString)] (expected [Collection(ecore::EString),ecore::EString])", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 244, 250, "[java.lang.Integer] cannot be removed from [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 267, 273, "[java.lang.Integer] cannot be removed from [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])", msg.get(1));
 	}
 	
 	/**
@@ -1193,7 +1193,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 134, 144, "Expected [ecore::EInt] but was [java.lang.String]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 134, 144, "Type mismatch: cannot assign [java.lang.String] to [ecore::EInt]", msg.get(0));
 	}
 	
 	/*
@@ -1501,7 +1501,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 66, 106, "Expected [ecore::EClass] but was [ecore::EOperation]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 66, 106, "Type mismatch: cannot assign [ecore::EOperation] to [ecore::EClass]", msg.get(0));
 	}
 	
 	@Test
@@ -1594,7 +1594,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 71, 101, "Expected [Collection(ecore::EInt)] but was [java.lang.Integer]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 71, 101, "Type mismatch: cannot assign [java.lang.Integer] to [Sequence(ecore::EInt)]", msg.get(0));
 	}
 	
 	@Test
@@ -1621,7 +1621,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 125, 143, "Type mismatch: cannot assign [Collection(java.lang.String)] to [Collection(ecore::EInt)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 125, 143, "Type mismatch: cannot assign [Sequence(java.lang.String)] to [Sequence(ecore::EInt)]", msg.get(0));
 	}
 	@Test
 	public void testAssignSequenceFeature() {
@@ -1646,8 +1646,8 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(2, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 143, 147, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 170, 192, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 143, 147, "Type mismatch: cannot assign [ecore::EClass] to [Sequence(ecore::EClass)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 170, 192, "Type mismatch: cannot assign [ecore::EClass] to [Sequence(ecore::EClass)]", msg.get(1));
 	}
 	@Test
 	public void testAssignSequenceVarDecl() {
@@ -1672,10 +1672,10 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(4, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 85, 128, "Expected [Collection(ecore::EClass)] but was [ecore::EClass]", msg.get(0));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 147, 151, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(1));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 155, 216, "Expected [Collection(ecore::EClass)] but was [ecore::EClass]", msg.get(2));
-		assertMsgEquals(ValidationMessageLevel.ERROR, 235, 257, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 85, 128, "Type mismatch: cannot assign [ecore::EClass] to [Sequence(ecore::EClass)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 147, 151, "Type mismatch: cannot assign [ecore::EClass] to [Sequence(ecore::EClass)]", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 155, 216, "Type mismatch: cannot assign [ecore::EClass] to [Sequence(ecore::EClass)]", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 235, 257, "Type mismatch: cannot assign [ecore::EClass] to [Sequence(ecore::EClass)]", msg.get(3));
 	}
 	
 	@Test
@@ -1701,7 +1701,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 110, 132, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 110, 132, "Type mismatch: cannot assign [ecore::EClass] to [Sequence(ecore::EClass)]", msg.get(0));
 	}
 	
 	@Test
@@ -1758,7 +1758,6 @@ public class TypeValidatorTest {
 		assertEquals("no error was expected but got: " + msg, 0, msg.size());
 	}
 	
-
 	@Test
 	public void testUnresolvedTypeInDeclarationError() {
 		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList(),Arrays.asList("input/validation/unresolvedTypeInDeclaration.implem"));
@@ -1772,6 +1771,80 @@ public class TypeValidatorTest {
 		assertEquals(2, msg.size());
 		assertMsgEquals(ValidationMessageLevel.ERROR, 64, 84, "Unresolved type , it cannot be found in any of the declared packages: [ecore, implementation, ast, test, unresolvedTypeInDecaration]", msg.get(0));
 		assertMsgEquals(ValidationMessageLevel.ERROR, 136, 157, "Unresolved type , it cannot be found in any of the declared packages: [ecore, implementation, ast, test, unresolvedTypeInDecaration]", msg.get(1));
+	}
+	
+	@Test
+	public void testAssignmentSequenceAndOrderedSetError() {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList() ,Arrays.asList("input/validation/assignmentSequenceAndOrderedSetError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(msg.toString(), 2, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 85, 108, "Type mismatch: cannot assign [Set(java.lang.Boolean)] to [Sequence(ecore::EBoolean)]\n------------------------------------------------------------------------------------\nCall anOrderedSet->asSequence() to allow assignment", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 152, 208, "Type mismatch: cannot assign [Sequence(ecore::EClass)] to [Set(ecore::EClass)]\n------------------------------------------------------------------------------\nCall aSequence->asOrderedSet() to allow assignment", msg.get(1));
+	}
+	
+	@Test
+	public void testAdditionAssignmentSequenceAndOrderedSet() {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList() ,Arrays.asList("input/validation/additionAssignmentSequenceAndOrderedSet.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(msg.toString(), 0, msg.size());
+	}
+	
+	@Test
+	public void testAdditionAssignmentSequenceAndOrderedSetError() {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList() ,Arrays.asList("input/validation/additionAssignmentSequenceAndOrderedSetError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(msg.toString(), 6, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 241, 260, "[Set(java.lang.Integer)] cannot be added to [Sequence(ecore::EBoolean)] (expected [Sequence(ecore::EBoolean),ecore::EBoolean])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 283, 305, "[Sequence(java.lang.String)] cannot be added to [Set(ecore::EClass)] (expected [Set(ecore::EClass),ecore::EClass])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 414, 433, "[Set(java.lang.Integer)] cannot be added to [Sequence(ecore::EBoolean)] (expected [Sequence(ecore::EBoolean),ecore::EBoolean])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 452, 474, "[Sequence(java.lang.String)] cannot be added to [Set(ecore::EClass)] (expected [Set(ecore::EClass),ecore::EClass])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 500, 519, "[Set(java.lang.Integer)] cannot be added to [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(4));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 539, 566, "[Sequence(java.lang.Boolean)] cannot be added to [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(5));
+	}
+	
+	@Test
+	public void testSubstractionAssignmentSequenceAndOrderedSet() {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList() ,Arrays.asList("input/validation/substractionAssignmentSequenceAndOrderedSet.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(msg.toString(), 0, msg.size());
+	}
+	
+	@Test
+	public void testSubstractionAssignmentSequenceAndOrderedSetError() {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList() ,Arrays.asList("input/validation/substractionAssignmentSequenceAndOrderedSetError.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(msg.toString(), 6, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 241, 260, "[Set(java.lang.Integer)] cannot be removed from [Sequence(ecore::EBoolean)] (expected [Sequence(ecore::EBoolean),ecore::EBoolean])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 283, 305, "[Sequence(java.lang.String)] cannot be removed from [Set(ecore::EClass)] (expected [Set(ecore::EClass),ecore::EClass])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(1));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 414, 433, "[Set(java.lang.Integer)] cannot be removed from [Sequence(ecore::EBoolean)] (expected [Sequence(ecore::EBoolean),ecore::EBoolean])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(2));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 452, 474, "[Sequence(java.lang.String)] cannot be removed from [Set(ecore::EClass)] (expected [Set(ecore::EClass),ecore::EClass])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(3));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 500, 519, "[Set(java.lang.Integer)] cannot be removed from [Sequence(ecore::EString)] (expected [Sequence(ecore::EString),ecore::EString])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(4));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 539, 566, "[Sequence(java.lang.Boolean)] cannot be removed from [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(5));
 	}
 	
 }

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -550,7 +550,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 81, 89, "[java.lang.String] cannot be added to [Collection(ecore::EClass)] (expected [Collection(ecore::EClass),ecore::EClass])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 81, 89, "[java.lang.String] cannot be added to [Set(ecore::EClass)] (expected [Set(ecore::EClass),ecore::EClass])", msg.get(0));
 	}
 	
 	/*
@@ -748,7 +748,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 80, 88, "[java.lang.String] cannot be removed from [Collection(ecore::EClass)] (expected [Collection(ecore::EClass),ecore::EClass])", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 80, 88, "[java.lang.String] cannot be removed from [Set(ecore::EClass)] (expected [Set(ecore::EClass),ecore::EClass])", msg.get(0));
 	}
 	
 	/*
@@ -1527,7 +1527,7 @@ public class TypeValidatorTest {
 		validator.validate(parsedSemantics);
 		List<IValidationMessage> msg = validator.getMessages();
 		
-		assertEquals(0, msg.size());
+		assertEquals(msg.toString(), 0, msg.size());
 	}
 	
 	@Test
@@ -1541,7 +1541,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 94, "Type mismatch: cannot assign [ecore::EClass] to [Collection(ecore::EClass)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 94, "Type mismatch: cannot assign [ecore::EClass] to [Set(ecore::EClass)]", msg.get(0));
 	}
 	
 	@Test
@@ -1555,7 +1555,7 @@ public class TypeValidatorTest {
 		List<IValidationMessage> msg = validator.getMessages();
 		
 		assertEquals(1, msg.size());
-		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 91, "Type mismatch: cannot assign [java.lang.Integer] to [Collection(ecore::EClass)]", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 90, 91, "Type mismatch: cannot assign [java.lang.Integer] to [Set(ecore::EClass)]", msg.get(0));
 	}
 	
 	@Test


### PR DESCRIPTION
Contributes to #67.

## Changes

- the `:=` operator forbids assignment of `Sequence` to `OrderedSet`, and vice versa
- the `+=` and `-=` operators now accept `OrderedSet` as left operand

## How to test

```kotlin
behavior helloworld

open class HelloWorld {

    OrderedSet(Integer) set := Sequence{1, 2}; // forbidden -> error message

    @main
    def void main() {
        OrderedSet(Integer) numbers;

        numbers += Sequence{1, 2, 3, 4};
        numbers -= OrderedSet{2, 4};

        numbers.log();
    }

}