### PR TITLE
[IDE] Update paths to resources when a container is renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#4](https://github.com/gemoc/ale-lang/issues/4) The .dsl configuration file and the .ale source file must have the same base name
 - [#64](https://github.com/gemoc/ale-lang/issues/64) Allow to assign `null` to variables
 - [#67](https://github.com/gemoc/ale-lang/issues/67) Forbid assignments from `Sequence` to `OrderedSet` and vice versa
+- [#70](https://github.com/gemoc/ale-lang/issues/70) Paths to ALE resources (in _.dsl_ files and projects' preferences) are not updated when the project is renamed
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
 - [#120](https://github.com/gemoc/ale-lang/issues/120) The `+=` operator cannot be used to concatenate two collections
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/preferences/AleProjectPreferences.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/preferences/AleProjectPreferences.java
@@ -13,7 +13,6 @@ package org.eclipse.emf.ecoretools.ale.core.preferences;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 /**

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/preferences/AleEnvironmentPropertyPage.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/preferences/AleEnvironmentPropertyPage.java
@@ -45,7 +45,6 @@ import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/services/Services.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/services/Services.java
@@ -52,6 +52,7 @@ import org.eclipse.emf.ecoretools.ale.core.interpreter.ExtensionEnvironment;
 import org.eclipse.emf.ecoretools.ale.core.interpreter.IAleEnvironment;
 import org.eclipse.emf.ecoretools.ale.core.parser.DslBuilder;
 import org.eclipse.emf.ecoretools.ale.core.parser.visitor.ParseResult;
+import org.eclipse.emf.ecoretools.ale.ide.Normalized;
 import org.eclipse.emf.ecoretools.ale.ide.project.AleProject;
 import org.eclipse.emf.ecoretools.ale.ide.ui.Activator;
 import org.eclipse.emf.ecoretools.ale.ide.ui.AlePreferenceStore;
@@ -558,7 +559,7 @@ public class Services {
 		URI uri = ecoreResource.getURI();
     	IPath path = new Path(uri.toPlatformString(false));
     	IProject enclosingProject = ResourcesPlugin.getWorkspace().getRoot().getFile(path).getProject();
-    	IAleEnvironment env = AleProject.from(enclosingProject).getEnvironment();
+    	IAleEnvironment env = new Normalized(AleProject.from(enclosingProject).getEnvironment());
     	
     	Pattern openClass = Pattern.compile(".*open\\s+class\\s+" + className + ".*");
     	

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.emf.ecoretools.ale,
  org.eclipse.emf.ecoretools.design,
  org.eclipse.emf.workspace,
  org.eclipse.sirius,
- org.eclipse.sirius.common
+ org.eclipse.sirius.common,
+ org.eclipse.ltk.core.refactoring
 Import-Package: org.eclipse.emf.common.util,
  org.eclipse.emf.ecore.resource.impl
 Export-Package: org.eclipse.emf.ecoretools.ale.ide,
@@ -19,3 +20,4 @@ Export-Package: org.eclipse.emf.ecoretools.ale.ide,
  org.eclipse.emf.ecoretools.ale.ide.project.impl,
  org.eclipse.emf.ecoretools.ale.ide.resource
 Bundle-Vendor: Inria/Obeo
+Bundle-Activator: org.eclipse.emf.ecoretools.ale.ide.Activator

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/plugin.xml
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/plugin.xml
@@ -33,5 +33,18 @@
           </run>
        </runtime>
     </extension>
+    <extension
+          point="org.eclipse.ltk.core.refactoring.renameParticipants">
+       <renameParticipant
+             class="org.eclipse.emf.ecoretools.ale.ide.refactoring.RenamePathsToAleResources"
+             id="org.eclipse.emf.ecoretools.ale.ide.renameParticipant.renamePathsInDslFiles"
+             name="Rename participant for *.dsl files">
+          <enablement>
+             <adapt
+                   type="org.eclipse.core.resources.IResource">
+             </adapt>
+          </enablement>
+       </renameParticipant>
+    </extension>
 
 </plugin>

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/Activator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/Activator.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.ide;
+
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
+import org.osgi.framework.BundleContext;
+
+public class Activator extends Plugin {
+	// The plug-in ID
+	public static final String PLUGIN_ID = "org.eclipse.emf.ecoretools.ale.ide";
+
+	// The shared instance
+	private static Activator plugin;
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 * 
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
+
+	public static void warn(String msg, Throwable e) {
+		Activator.getDefault().getLog().log(new Status(Status.WARNING, PLUGIN_ID, Status.OK, msg, e));
+	}
+
+	public static void error(String msg, Throwable e) {
+		Activator.getDefault().getLog().log(new Status(Status.ERROR, PLUGIN_ID, Status.OK, msg, e));
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/project/AleProject.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/project/AleProject.java
@@ -49,6 +49,22 @@ public interface AleProject {
 	}
 	
 	/**
+	 * Checks whether a given project has the ALE nature.
+	 * 
+	 * @param project
+	 * 			The project to check
+	 * 
+	 * @return true if the project has the ALE nature, false otherwise
+	 */
+	static boolean hasAleNature(IProject project) {
+		try {
+			return project.hasNature(AleProjectNature.ID);
+		} catch (CoreException e) {
+			return false;
+		}
+	}
+	
+	/**
 	 * Creates the project if it does not exist yet.
 	 * 
 	 * @param name

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/refactoring/RenamePathsInDslFilesChange.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/refactoring/RenamePathsInDslFilesChange.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.ide.refactoring;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.emf.ecoretools.ale.core.parser.Dsl;
+import org.eclipse.emf.ecoretools.ale.ide.Activator;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+/**
+ * A change that updates the paths to ALE resources in a project's .dsl configuration file.
+ * <p>
+ * This change is supposed to occur <strong>after</strong> that the project has been renamed.
+ */
+public class RenamePathsInDslFilesChange extends Change {
+	
+	private final IFile dslFile;
+	private final Collection<String> behaviors;
+	private final Collection<String> metamodels;
+
+	/**
+	 * Creates a new change that updates paths to ALE resources in a project's .dsl configuration file.
+	 * 
+	 * @param dslFile
+	 * 			The .dsl file to update
+	 * @param behaviors
+	 * 			The new URIs to environment's behaviors 
+	 * @param metamodels
+	 * 			The new URIs to environment's metamodels 
+	 */
+	public RenamePathsInDslFilesChange(IFile dslFile, Collection<String> behaviors, Collection<String> metamodels) {
+		super();
+		this.dslFile = requireNonNull(dslFile, "dslFile");
+		this.behaviors = requireNonNull(behaviors, "behaviors");
+		this.metamodels = requireNonNull(metamodels, "metamodels");
+	}
+
+	@Override
+	public String getName() {
+		return "Update paths in '" + dslFile.getFullPath() + "'";
+	}
+
+	@Override
+	public void initializeValidationData(IProgressMonitor pm) {
+		// nothing to do
+	}
+
+	@Override
+	public RefactoringStatus isValid(IProgressMonitor pm) throws CoreException {
+		// Actually dslFile.exists() is always false here (and within initialize)
+		// so the lines below are not a reliable way to check change's validity
+		
+//		if (!dslFile.exists()) {
+//			return RefactoringStatus.createFatalErrorStatus(dslFile.getFullPath() + " does not exist");
+//		}
+//		if (dslFile.isReadOnly()) {
+//			return RefactoringStatus.createFatalErrorStatus(dslFile.getFullPath() + " is read-only");
+//		}
+		return RefactoringStatus.create(Status.OK_STATUS);
+	}
+
+	@Override
+	public Object getModifiedElement() {
+		return dslFile;
+	}
+	
+	@Override
+	public Object[] getAffectedObjects() {
+		return new Object[] { dslFile };
+	}
+
+	@Override
+	public Change perform(IProgressMonitor monitor) throws CoreException {
+		try {
+			Dsl dsl = new Dsl(dslFile.getLocation().toOSString());
+			
+			Collection<String> currentBehaviors = new LinkedHashSet<>(dsl.getBehaviors());
+			Collection<String> currentMetamodels = new LinkedHashSet<>(dsl.getMetamodels());
+			
+			dsl.getBehaviors().clear();
+			dsl.getMetamodels().clear();
+			
+			dsl.getBehaviors().addAll(behaviors);
+			dsl.getMetamodels().addAll(metamodels);
+			
+			dsl.save();
+			
+			Change undo = new RenamePathsInDslFilesChange(dslFile, currentBehaviors, currentMetamodels);
+			return undo;
+		}
+		catch (Exception e) {
+			Activator.warn("Unable to rename paths in " + dslFile.getFullPath(), e);
+		}
+		finally {
+			monitor.done();
+		}
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/refactoring/RenamePathsInProjectPreferencesChange.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/refactoring/RenamePathsInProjectPreferencesChange.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.ide.refactoring;
+
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.emf.ecoretools.ale.core.preferences.AleProjectPreferences.ALE_SOURCE_FILES;
+import static org.eclipse.emf.ecoretools.ale.core.preferences.AleProjectPreferences.CONFIGURED_FROM_DSL_FILE;
+import static org.eclipse.emf.ecoretools.ale.core.preferences.AleProjectPreferences.DSL_FILE_PATH;
+import static org.eclipse.emf.ecoretools.ale.core.preferences.AleProjectPreferences.ECORE_MODEL_FILES;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecoretools.ale.core.preferences.AleProjectPreferences;
+import org.eclipse.emf.ecoretools.ale.ide.Activator;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.osgi.service.prefs.BackingStoreException;
+
+/**
+ * A change that updates the paths to ALE resources in a project's preferences.
+ * <p>
+ * This change is supposed to occur <strong>after</strong> that the project has been renamed.
+ * <p>
+ * Those preferences are identified by {@link AleProjectPreferences}. 
+ */
+public class RenamePathsInProjectPreferencesChange extends Change {
+	
+	private final IProject project;
+	private final IFile oldDslFile;
+	private final IFile newDslFile;
+	private final Collection<String> behaviors;
+	private final Collection<String> metamodels;
+
+	/**
+	 * Creates a new change that updates paths to ALE resources in a project's preferences.
+	 * 
+	 * @param project
+	 * 			The project which preferences must be updated
+	 * @param oldDslFile
+	 * 			The .dsl file used to configure the project before its renaming,
+	 * 			or null if the project doesn't use any
+	 * @param newDslFile
+	 * 			The .dsl file used to configure the project after its renaming,
+	 * 			or null if the project doesn't use any
+	 * @param behaviors
+	 * 			The new URIs to environment's behaviors 
+	 * @param metamodels
+	 * 			The new URIs to environment's metamodels 
+	 */
+	public RenamePathsInProjectPreferencesChange(IProject project, IFile oldDslFile, IFile newDslFile, Collection<String> behaviors, Collection<String> metamodels) {
+		super();
+		this.project = requireNonNull(project, "project");
+		this.oldDslFile = oldDslFile;
+		this.newDslFile = newDslFile;
+		this.behaviors = requireNonNull(behaviors, "behaviors");
+		this.metamodels = requireNonNull(metamodels, "metamodels");
+	}
+
+	@Override
+	public String getName() {
+		return "Update preferences of '" + project.getName() + "'";
+	}
+
+	@Override
+	public void initializeValidationData(IProgressMonitor pm) {
+		// nothing to do
+	}
+
+	@Override
+	public RefactoringStatus isValid(IProgressMonitor pm) throws CoreException {
+		// Actually project.exists() is always false here (and within initialize)
+		// so the lines below are not a reliable way to check change's validity
+		
+//		if (!project.exists()) {
+//			return RefactoringStatus.createFatalErrorStatus("project '" + project.getName() + "' does not exist");
+//		}
+		return RefactoringStatus.create(Status.OK_STATUS);
+	}
+
+	@Override
+	public Object getModifiedElement() {
+		return project;
+	}
+	
+	@Override
+	public Object[] getAffectedObjects() {
+		return new Object[] { project };
+	}
+	
+	@Override
+	public Change perform(IProgressMonitor monitor) throws CoreException {
+		IScopeContext context = new ProjectScope(project);
+        IEclipsePreferences preferences = context.getNode("org.eclipse.emf.ecoretools.ale.core");
+        
+    	if (newDslFile != null) {
+        	URI dslFileURI = URI.createPlatformResourceURI(newDslFile.getFullPath().toPortableString(), true);
+			preferences.put(DSL_FILE_PATH.property(), dslFileURI.toString());
+        }
+    	List<String> currentBehaviors = asList(preferences.get(ALE_SOURCE_FILES.property(), "").split(","));
+    	List<String> currentMetamodels = asList(preferences.get(ECORE_MODEL_FILES.property(), "").split(","));
+        boolean pathsAreStoredInPreferences = !preferences.getBoolean(CONFIGURED_FROM_DSL_FILE.property(), false);
+		if (pathsAreStoredInPreferences) {
+        	preferences.put(ALE_SOURCE_FILES.property(), commaSeparated(behaviors));
+        	preferences.put(ECORE_MODEL_FILES.property(), commaSeparated(metamodels));
+        }
+		try {
+			preferences.flush();
+			
+			Change undo = new RenamePathsInProjectPreferencesChange(project, newDslFile, oldDslFile, currentBehaviors, currentMetamodels);
+			return undo;
+		} 
+		catch (BackingStoreException e) {
+			Activator.error("Unable to update " + project.getName() + "'s preferences impacted by refactoring", e);
+		}
+		return null;
+	}
+	
+	private static String commaSeparated(Collection<String> elements) {
+		return String.join(",", elements);
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/refactoring/RenamePathsToAleResources.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/refactoring/RenamePathsToAleResources.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.ide.refactoring;
+
+import static java.util.Arrays.asList;
+import static org.eclipse.emf.ecoretools.ale.core.preferences.AleProjectPreferences.CONFIGURED_FROM_DSL_FILE;
+import static org.eclipse.emf.ecoretools.ale.core.preferences.AleProjectPreferences.DSL_FILE_PATH;
+import static org.eclipse.emf.ecoretools.ale.ide.project.AleProject.hasAleNature;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecoretools.ale.core.interpreter.IAleEnvironment;
+import org.eclipse.emf.ecoretools.ale.core.parser.Dsl;
+import org.eclipse.emf.ecoretools.ale.ide.Activator;
+import org.eclipse.emf.ecoretools.ale.ide.project.AleProject;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
+import org.eclipse.ltk.core.refactoring.participants.RenameParticipant;
+
+public class RenamePathsToAleResources extends RenameParticipant {
+	
+	private IContainer renamed;
+
+	@Override
+	protected boolean initialize(Object element) {
+		if (! (element instanceof IContainer)) {
+			return false;
+		}
+		renamed = (IContainer) element;
+		return true;
+	}
+
+	@Override
+	public String getName() {
+		return "Rename paths to ALE resources files when the enclosing project is renamed";
+	}
+
+	@Override
+	public RefactoringStatus checkConditions(IProgressMonitor pm, CheckConditionsContext context) throws OperationCanceledException {
+		return new RefactoringStatus();
+	}
+
+	@Override
+	public Change createChange(IProgressMonitor pm) throws CoreException {
+		String newName = getArguments().getNewName();
+		
+		CompositeChange changes = new CompositeChange("Update paths to ALE resources");
+		changeMadeToProject(newName).ifPresent(changes::add);
+		changesMadeToDslFiles(newName).forEach(changes::add);
+		
+		return changes;
+	}
+	
+	private Optional<Change> changeMadeToProject(String newName) {
+		IProject project = renamed.getProject();
+		if (!hasAleNature(project)) {
+			// the project is not interested in our changes
+			return Optional.empty();
+		}
+		IFile oldDslFile = findDslConfigurationFile(project);
+		IFile newDslFile = oldDslFile == null ? oldDslFile : toWorkspace(uriAfterRenaming(oldDslFile, newName));
+		IProject newProject = projectAfterRename(renamed, newName);
+		IAleEnvironment env = AleProject.from(project).getEnvironment();
+		Collection<String> newBehaviors = renamedIfImpacted(env.getBehaviors(), newName);
+		Collection<String> newMetamodels = renamedIfImpacted(env.getMetamodels(), newName);
+
+		Change change = new RenamePathsInProjectPreferencesChange(newProject, oldDslFile, newDslFile, newBehaviors, newMetamodels);
+		return Optional.of(change);
+	}
+	
+	private List<Change> changesMadeToDslFiles(String newName) throws CoreException {
+		List<Change> changes = new ArrayList<>();
+		
+		renamed.getProject().accept(new IResourceVisitor() {
+			
+			@Override
+			public boolean visit(IResource resource) throws CoreException {
+				if (resource instanceof IFile && resource.getName().endsWith(".dsl")) {
+					IFile file = (IFile) resource;
+					try {
+						IFile fileAfterRenaming = toWorkspace(uriAfterRenaming(file, newName));
+
+						Dsl dsl = new Dsl(file.getLocation().toOSString());
+						Collection<String> newBehaviors = renamedIfImpacted(dsl.getBehaviors(), newName);
+						Collection<String> newMetamodels = renamedIfImpacted(dsl.getMetamodels(), newName);
+						
+						changes.add(new RenamePathsInDslFilesChange(fileAfterRenaming, newBehaviors, newMetamodels));
+					} 
+					catch (Exception e) {
+						Activator.warn("Unable to rename paths in " + file.getFullPath(), e);
+					}
+				}
+				return true;
+			}
+		});
+		return changes;
+	}
+
+	/** @return the .dsl file used to configure ALE, or null if the project doesn't use one */
+	private IFile findDslConfigurationFile(IProject project) {
+		IScopeContext context = new ProjectScope(project);
+		IEclipsePreferences preferences = context.getNode("org.eclipse.emf.ecoretools.ale.core");
+		
+		boolean isConfiguredFromDslFile = preferences.getBoolean(CONFIGURED_FROM_DSL_FILE.property(), false);
+		if (isConfiguredFromDslFile) {
+			try {
+				URI dslFileURI = URI.createURI(preferences.get(DSL_FILE_PATH.property(), ""));
+				return toWorkspace(dslFileURI);
+			} 
+			catch (IllegalArgumentException | NullPointerException e) {
+				// preferences are not properly set, the change won't do much
+			}
+		}
+		return null;
+	}
+
+	/** @return all given URIs, but updating the ones impacted by the renaming */
+	private LinkedHashSet<String> renamedIfImpacted(Collection<String> uris, String newName) {
+		LinkedHashSet<String> renamedURIs = new LinkedHashSet<>();
+		
+		for (String uri : uris) {
+			boolean uriHasBeenRenamed = false;
+			Set<IFile> files = toWorkspaceFiles(uri);
+			
+			for (IFile file : files) {
+				if (isImpactedByRenaming(file)) {
+					String renamedURI = uriAfterRenaming(file, newName).toString();
+
+					renamedURIs.add(renamedURI);
+					uriHasBeenRenamed = true;
+				}
+			}
+			if (!uriHasBeenRenamed) {
+				renamedURIs.add(uri);
+			}
+		}
+		return renamedURIs;
+	}
+	
+	/** @return the project that will contain the given resource after the rename operation */
+	private static IProject projectAfterRename(IResource resource, String newName) {
+		boolean theProjectIsBeingRenamed = resource.equals(resource.getProject());
+		if (theProjectIsBeingRenamed) {
+			return ResourcesPlugin.getWorkspace().getRoot().getProject(newName);
+		}
+		else {
+			return resource.getProject();
+		}
+	}
+
+	/** @return the URI that identifies the file once it has been renamed 
+	 * 			(uses the platform:/resource/ scheme) */
+	private URI uriAfterRenaming(IFile file, String newName) {
+		IPath newPath = pathAfterRenaming(file, newName);
+		URI newURI = URI.createPlatformResourceURI(newPath.toString(), true);
+		return newURI;
+	}
+
+	/** @return the new path of the given file once {@link #renamed} is renamed as newName */
+	private IPath pathAfterRenaming(IFile file, String newName) {
+		if (!isImpactedByRenaming(file)) {
+			return file.getFullPath();
+		}
+		IPath containerPath = renamed.getFullPath().removeLastSegments(1);
+		IPath containerPathAfterRenaiming = containerPath.append(newName);
+		IPath relativeFilePath = file.getFullPath().removeFirstSegments(renamed.getFullPath().segmentCount());
+		return containerPathAfterRenaiming.append(relativeFilePath);
+	}
+
+	/** @return whether the path of the given file will change once {@link #renamed} is renamed */
+	private boolean isImpactedByRenaming(IFile file) {
+		return file.getFullPath().matchingFirstSegments(renamed.getFullPath()) == renamed.getFullPath().segmentCount();
+	}
+
+	/** @return the files of the workspace identified by given URI */
+	private static Set<IFile> toWorkspaceFiles(String uri) {
+		try {
+			URI behaviorURI = URI.createURI(uri);
+			return toWorkspace(new File(toAbsoluteFilePath(behaviorURI)));
+		}
+		catch (NullPointerException e) {
+			// the file identified by the URI does not exist
+			return new HashSet<>();
+		}
+	}
+	
+	/** @return the system-absolute path of the file identified by the given URI */
+	private static String toAbsoluteFilePath(URI uri) {
+		IWorkspace ws = ResourcesPlugin.getWorkspace();
+		if(ws != null) {
+			IResource file = ws.getRoot().findMember(uri.toPlatformString(true));
+			if(file != null) {
+				return file.getLocationURI().getRawPath();
+			}
+		}
+		return null;
+	}
+	
+	/** @return the files of the workspace that correspond to the given file */
+	private static Set<IFile> toWorkspace(File file) {
+		java.net.URI location = file.toURI();
+		IFile[] files = ResourcesPlugin.getWorkspace().getRoot()
+									   .findFilesForLocationURI(location);
+		return new HashSet<>(asList(files));
+	}
+	
+	/** @return the file of the workspace identified by the given URI */
+	private static IFile toWorkspace(URI uri) {
+		return ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(uri.toPlatformString(true)));
+	}
+
+}


### PR DESCRIPTION
Closes #70.

## Changes

- paths in both _.dsl_ files and project preferences are updated when:
  - the enclosing project is renamed
  - a folder containing an ALE resource (source file / metamodel) is renamed
- undo operation is supported

## Demo

<details>

  <summary><i>Click to show</i></summary>

<br/>

![demo-issue-70](https://user-images.githubusercontent.com/25926433/81323288-7410b400-9095-11ea-818f-bc7cbc749fcd.gif)

</details>

## Change preview

I also wanted to implement a preview of the changes (in a textual diff) but I found no code to reuse and that would thus have costed too much time. The steps are:

1. Contribute to the `org.eclipse.ltk.ui.refactoring.changePreviewViewers` extension point
2. Provide a class implementing `org.eclipse.ltk.ui.refactoring.IChangePreviewViewer`

## Other changes

 - AleAware.getEnvironment() does not return a `Normalized` instance anymore. `Normalized` was turning each source file URI into an absolute file path, making code in Rename participants cumbersome. `DslBuilder` is instead charged of turning URI into files before feeding them to ANTLR.

Those details will be clean up by #123

## Comments

@dvojtise I believe that the code updating the _.dsl_ file could (and should?) be moved to the GEMOC Studio. Kind of related to https://github.com/eclipse/gemoc-studio/issues/161