### PR TITLE
[Type Checker] Handle dynamic classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - [#4](https://github.com/gemoc/ale-lang/issues/4) The .dsl configuration file and the .ale source file must have the same base name
-- [#64](https://github.com/gemoc/ale-lang/issues/64) Allow to assign `null` to variables
-- [#67](https://github.com/gemoc/ale-lang/issues/67) Forbid assignments from `Sequence` to `OrderedSet` and vice versa
+- [#51](https://github.com/gemoc/ale-lang/issues/51) Pure ALE classes are not handled by the type checker
+- [#64](https://github.com/gemoc/ale-lang/issues/64) `null` cannot be assigned to variables
+- [#67](https://github.com/gemoc/ale-lang/issues/67) `Sequence` vales can be assigned to variable which type is `OrderedSet` and vice versa
 - [#70](https://github.com/gemoc/ale-lang/issues/70) Paths to ALE resources (in _.dsl_ files and projects' preferences) are not updated when the project is renamed
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
 - [#120](https://github.com/gemoc/ale-lang/issues/120) The `+=` operator cannot be used to concatenate two collections

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/AstBuilder.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/AstBuilder.java
@@ -117,11 +117,13 @@ public class AstBuilder {
 				while(topPkg.getESuperPackage() != null){
 					topPkg = topPkg.getESuperPackage();
 				}
-				// TODO Check whether qryEnv.removeEPackage(topPkg) should be called before
-				// 		There is a show stopper preventing the package to be registered again
-				//		-- could it prevent package updates?
-				//		See: https://git.eclipse.org/c/acceleo/org.eclipse.acceleo.git/tree/query/plugins/org.eclipse.acceleo.query/src/org/eclipse/acceleo/query/runtime/impl/EPackageProvider.java#n265
-				//			 (commit 	41f1588)
+				
+				// removeEPackage() is called to make sure the package is updated
+				// Otherwise a show stopper prevents the package to be registered again
+				//
+				// See: https://git.eclipse.org/c/acceleo/org.eclipse.acceleo.git/tree/query/plugins/org.eclipse.acceleo.query/src/org/eclipse/acceleo/query/runtime/impl/EPackageProvider.java#n265
+				//	    (commit 	41f1588)
+				qryEnv.removeEPackage(topPkg);
 				qryEnv.registerEPackage(topPkg);
 			});
 		

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignmentsInvolvingRuntimeClasses.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/input/validation/assignmentsInvolvingRuntimeClasses.implem
@@ -1,0 +1,20 @@
+behavior helloworld;
+
+open class EClass {
+	
+	helloworld::MyClass attribute;
+	
+	@main
+	def void main() {
+		helloworld::MyClass aMyClass;
+		aMyClass := helloworld::MyClass.create();
+		ecore::EClass helloworld := aMyClass.refEClass;
+		
+		aMyClass := self.attribute;	
+		aMyClass := self;	
+	}
+}
+
+class MyClass {
+	EClass refEClass;
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/TypeValidatorTest.java
@@ -1847,4 +1847,17 @@ public class TypeValidatorTest {
 		assertMsgEquals(ValidationMessageLevel.ERROR, 539, 566, "[Sequence(java.lang.Boolean)] cannot be removed from [Sequence(ecore::EInt)] (expected [Sequence(ecore::EInt),ecore::EInt])\n--------------------------------------------------\nMake sure both collections hold the same type", msg.get(5));
 	}
 	
+	@Test
+	public void testAssignmentsInvolvingRuntimeClassesAreTypeChecked() {
+		IAleEnvironment environment = new RuntimeAleEnvironment(Arrays.asList() ,Arrays.asList("input/validation/assignmentsInvolvingRuntimeClasses.implem"));
+		List<ParseResult<ModelUnit>> parsedSemantics = (new DslBuilder(interpreter.getQueryEnvironment())).parse(environment);
+		
+		ALEValidator validator = new ALEValidator(interpreter.getQueryEnvironment());
+		validator.validate(parsedSemantics);
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(msg.toString(), 1, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 278, 282, "Type mismatch: cannot assign [ecore::EClass] to [helloworld::MyClass]", msg.get(0));
+	}
+	
 }


### PR DESCRIPTION
Closes #51

Make sure that the `EPackage` containing the dynamic classes is actually taken into account by forcing the environment to remove the previously registered `EPackage`.

## How to test

```kotlin
behavior helloworld;

open class EClass {
	
	helloworld::MyClass attribute;
	
	@main
	def void main() {
		helloworld::MyClass aMyClass;
		aMyClass := helloworld::MyClass.create();
		ecore::EClass helloworld := aMyClass.refEClass;

		aMyClass := self.attribute;	
		aMyClass := self;	  // shows an error
	}
}

class MyClass {
	EClass refEClass;
}
``` 