### PR TITLE
[Sirius] Enhance the 'Behavior' layer to handle split projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - [#4](https://github.com/gemoc/ale-lang/issues/4) The .dsl configuration file and the .ale source file must have the same base name
+- [#39](https://github.com/gemoc/ale-lang/issues/39) Sirius' _Behavior_ layer does not show runtime data when _.ale_ and _.ecore_ files are defined in different projects
 - [#51](https://github.com/gemoc/ale-lang/issues/51) Pure ALE classes are not handled by the type checker
 - [#64](https://github.com/gemoc/ale-lang/issues/64) `null` cannot be assigned to variables
 - [#67](https://github.com/gemoc/ale-lang/issues/67) `Sequence` vales can be assigned to variable which type is `OrderedSet` and vice versa


### PR DESCRIPTION
Closes #39

## Details
 - when an ALE project contains a Sirius representation, this representation can show
   both static and dynamic data, even if the metamodel(s) and the source file(s) are
   in other projects

## Changes

 - the project is retrieved from the location of the .aird file
 - the ALE environment is loaded from this project and used to fed the Behavior layer

## Screenshot

The capture below show a workspace with two project:

 - `minifsm` defines a FSM metamodel
 - `minifsm-execution` defines a semantics for this FSM

The Sirius representation defined by `minifsm-execution` can show the semantics defined in the `minifsm-execution`:

![image](https://user-images.githubusercontent.com/25926433/81340119-96173000-90af-11ea-9671-3878daf1322e.png)

> *Note*: don't mind the red crosses, it looks like some icons are missing in my environment