### PR TITLE
[IDE] Use "ecore" and "ale" keys instead of "syntax" and "semantics" in .dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [] - 2019-12-08
 ### Changed
+- [#26](https://github.com/gemoc/ale-lang/issues/26) Use `ecore` and `ale` keys instead of `syntax` and `semantics` in *.dsl* files **[breaking change]**
 - [#56](https://github.com/gemoc/ale-lang/issues/56) The interpreter now affects a default value to variables declared without an initial one
 
 ### Fixed

--- a/examples/logo.example/data/LogoProgram.dsl
+++ b/examples/logo.example/data/LogoProgram.dsl
@@ -1,2 +1,2 @@
-syntax=platform:/resource/logo.model/model/ASMLogo.ecore,platform:/resource/logo.model/model/VMLogo.ecore
-behavior=platform:/resource/logo.example/data/LogoProgram.ale
+ecore=platform:/resource/logo.model/model/ASMLogo.ecore,platform:/resource/logo.model/model/VMLogo.ecore
+ale=platform:/resource/logo.example/data/LogoProgram.ale

--- a/examples/logo.example/data/logo.dsl
+++ b/examples/logo.example/data/logo.dsl
@@ -1,2 +1,2 @@
-syntax=platform:/resource/logo.model/model/ASMLogo.ecore,platform:/resource/logo.model/model/VMLogo.ecore
-behavior=platform:/resource/logo.example/data/LogoProgram.ale
+ecore=platform:/resource/logo.model/model/ASMLogo.ecore,platform:/resource/logo.model/model/VMLogo.ecore
+ale=platform:/resource/logo.example/data/LogoProgram.ale

--- a/examples/logo.standalone/logo-standalone.dsl
+++ b/examples/logo.standalone/logo-standalone.dsl
@@ -1,2 +1,2 @@
-syntax=../logo.model/model/ASMLogo.ecore,../logo.model/model/VMLogo.ecore,
-behavior=../logo.example/data/LogoProgram.ale
+ecore=../logo.model/model/ASMLogo.ecore,../logo.model/model/VMLogo.ecore,
+ale=../logo.example/data/LogoProgram.ale

--- a/examples/minifsm/model/MiniFsm.dsl
+++ b/examples/minifsm/model/MiniFsm.dsl
@@ -1,2 +1,2 @@
-syntax=platform:/resource/minifsm/model/MiniFsm.ecore
-behavior=platform:/resource/minifsm/model/MiniFsm.ale
+ecore=platform:/resource/minifsm/model/MiniFsm.ecore
+ale=platform:/resource/minifsm/model/MiniFsm.ale

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/env/impl/FileBasedAleEnvironment.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/env/impl/FileBasedAleEnvironment.java
@@ -46,8 +46,8 @@ import org.eclipse.emf.ecoretools.ale.core.io.IOResources;
 //		      the .dsl file in the constructor
 public final class FileBasedAleEnvironment extends AbstractAleEnvironment {
 	
-	public static final String BEHAVIORS_KEY = "behavior";
-	public static final String METAMODELS_KEY = "syntax";
+	public static final String BEHAVIORS_KEY = "ale";
+	public static final String METAMODELS_KEY = "ecore";
 	
 	private File platformFile;
 	private IFile workspaceFile;

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/listener/AleSessionManagerListener.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/listener/AleSessionManagerListener.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.common.command.CommandStack;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecoretools.ale.core.env.impl.FileBasedAleEnvironment;
 import org.eclipse.emf.ecoretools.ale.ide.resource.AleResource;
 import org.eclipse.emf.ecoretools.design.service.EcoreToolsDesignPlugin;
 import org.eclipse.emf.transaction.RecordingCommand;
@@ -159,7 +160,7 @@ public class AleSessionManagerListener implements SessionManagerListener {
 			IPath dslPath = file.getFullPath().removeFileExtension().addFileExtension(DSL_EXTENSION);
 			
 			String aleContent = "behavior "+ getSimpleName(ecoreResource) +";\n";
-			String dslContent = "syntax=" + ecoreURI + "\nbehavior=" + aleURI + "\n";
+			String dslContent = FileBasedAleEnvironment.METAMODELS_KEY + "=" + ecoreURI + "\n" + FileBasedAleEnvironment.BEHAVIORS_KEY + "=" + aleURI + "\n";
 			
 			createFile(alePath, aleContent);
 			createFile(dslPath, dslContent);


### PR DESCRIPTION
Close #26.

Use the `ecore` and `ale` keys in *.dsl* because they are the keys understood by the GEMOC Studio:

*fsm.dsl*
```properties
ecore=platform\:/resource/fsm/model/fsm.ecore
ale=platform\:/resource/fsm/src-ale/fsm.ale
```

By the way @dvojtise, do we really want to use `ale` as a key? If I remember well we had a discussion with other members of the team and kind of agreed for `org.eclipse.emf.ecoretools.ale.interpreter` instead. Am I right? I so, should I make the change right now or postpone it and merge the PR anyway?