### PR TITLE
Make Xtext validators resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
 - [#120](https://github.com/gemoc/ale-lang/issues/120) The `+=` operator cannot be used to concatenate two collections
 - [#126](https://github.com/gemoc/ale-lang/issues/126) The interpreter evaluates an expression even if a subexpression produces an error
-- [#128](https://github.com/gemoc/ale-lang/issues/128) The interpreter allows to concatenate heterogeneous collections
+- [#126](https://github.com/gemoc/ale-lang/issues/126) The interpreter evaluates an expression even if a subexpression produces an error
+- [#149](https://github.com/gemoc/ale-lang/issues/149) Xtext validators are not resilient
 
 ### Added
 - [#60](https://github.com/gemoc/ale-lang/issues/60) An ALE Run Configuration is created when launching ALE through the contextual menu shortcut

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToAleBehaviorsFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToAleBehaviorsFactory.java
@@ -559,6 +559,8 @@ public class AntlrAstToAleBehaviorsFactory {
 			.stream()
 			.filter(cls -> !cls.getEPackage().getName().equals("implementation"))
 			.filter(cls -> cls.getName().equals(className))
+			// FIXME Should return all candidates to outline the fact that namesakes
+			// 		 have been found & allow to address the issue thereafter in validators
 			.findFirst();
 		
 		if(candidate.isPresent())

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
@@ -133,48 +133,49 @@ public class NameValidator implements IValidator {
 		//TODO: check cycles in 'extends'
 		msgs.addAll(validateBehavioredClass(xtdClass));
 		
-		/*
-		 * Check name of base class attributes
-		 */
-		List<String> declarations = 
+		if (xtdClass.getBaseClass() != null) {
+			/*
+			 * Check name of base class attributes
+			 */
+			List<String> declarations = 
+				xtdClass
+				.getBaseClass()
+				.getEAllStructuralFeatures()
+				.stream().map(s -> s.getName())
+				.collect(Collectors.toList());
 			xtdClass
-			.getBaseClass()
-			.getEAllStructuralFeatures()
-			.stream().map(s -> s.getName())
-			.collect(Collectors.toList());
-		xtdClass
-		.getAttributes()
-		.stream()
-		.forEach(att -> {
-			String name = att.getFeatureRef().getName();
-			if(declarations.contains(name)) {
-				msgs.add(new ValidationMessage(
-						ValidationMessageLevel.ERROR,
-						String.format(NAME_ALREADY_USED, name),
-						base.getStartOffset(att),
-						base.getEndOffset(att)
-						));
-			}
-		});
-		
-		/*
-		 * Check def methods must not override
-		 */
-		EList<EOperation> allEOperations = xtdClass.getBaseClass().getEAllOperations();
-		for (Method mtd : xtdClass.getMethods()) {
-			EOperation opRef = mtd.getOperationRef();
-			if(opRef!= null && opRef.getEContainingClass() != xtdClass.getBaseClass()) {
-				if(allEOperations.stream().anyMatch(op -> isMatching(opRef, op))){
+			.getAttributes()
+			.stream()
+			.forEach(att -> {
+				String name = att.getFeatureRef().getName();
+				if(declarations.contains(name)) {
 					msgs.add(new ValidationMessage(
-						ValidationMessageLevel.ERROR,
-						String.format(OP_MUST_OVERRIDE, getSignature(mtd)),
-						base.getStartOffset(mtd),
-						base.getEndOffset(mtd)
-						));
+							ValidationMessageLevel.ERROR,
+							String.format(NAME_ALREADY_USED, name),
+							base.getStartOffset(att),
+							base.getEndOffset(att)
+							));
+				}
+			});
+			
+			/*
+			 * Check def methods must not override
+			 */
+			EList<EOperation> allEOperations = xtdClass.getBaseClass().getEAllOperations();
+			for (Method mtd : xtdClass.getMethods()) {
+				EOperation opRef = mtd.getOperationRef();
+				if(opRef!= null && opRef.getEContainingClass() != xtdClass.getBaseClass()) {
+					if(allEOperations.stream().anyMatch(op -> isMatching(opRef, op))){
+						msgs.add(new ValidationMessage(
+							ValidationMessageLevel.ERROR,
+							String.format(OP_MUST_OVERRIDE, getSignature(mtd)),
+							base.getStartOffset(mtd),
+							base.getEndOffset(mtd)
+							));
+					}
 				}
 			}
 		}
-		
 		return msgs;
 	}
 	

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/SafeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/SafeValidator.java
@@ -1,0 +1,202 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools.ale.core.validation;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.acceleo.query.runtime.IValidationMessage;
+import org.eclipse.emf.ecoretools.ale.core.Activator;
+import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
+import org.eclipse.emf.ecoretools.ale.implementation.FeatureAssignment;
+import org.eclipse.emf.ecoretools.ale.implementation.FeatureInsert;
+import org.eclipse.emf.ecoretools.ale.implementation.FeatureRemove;
+import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
+import org.eclipse.emf.ecoretools.ale.implementation.If;
+import org.eclipse.emf.ecoretools.ale.implementation.Method;
+import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
+import org.eclipse.emf.ecoretools.ale.implementation.RuntimeClass;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableAssignment;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableInsert;
+import org.eclipse.emf.ecoretools.ale.implementation.VariableRemove;
+import org.eclipse.emf.ecoretools.ale.implementation.While;
+
+/**
+ * Decorates a {@link IValidator} in order to surround all its method calls
+ * with a try-catch statement. Exceptions are logged through the {@link Activator}
+ * and an empty list is returned instead. 
+ */
+public final class SafeValidator implements IValidator {
+
+	private final IValidator unsafeValidator;
+
+	public SafeValidator(IValidator validator) {
+		this.unsafeValidator = Objects.requireNonNull(validator, "validator");
+	}
+
+	public void setBase(BaseValidator baseValidator) {
+		unsafeValidator.setBase(baseValidator);
+	}
+
+	public List<IValidationMessage> validateModelBehavior(List<ModelUnit> units) {
+		try {
+			return unsafeValidator.validateModelBehavior(units);
+		} 
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating ModelBehavior: " + units, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateModelUnit(ModelUnit unit) {
+		try {
+			return unsafeValidator.validateModelUnit(unit);
+		} 
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating ModelUnit: " + unit, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateExtendedClass(ExtendedClass xtdClass) {
+		try {
+			return unsafeValidator.validateExtendedClass(xtdClass);
+		} 
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating ExtendedClass: " + xtdClass, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateRuntimeClass(RuntimeClass classDef) {
+		try {
+			return unsafeValidator.validateRuntimeClass(classDef);
+		} 
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating RuntimeClass: " + classDef, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateMethod(Method mtd) {
+		try {
+			return unsafeValidator.validateMethod(mtd);
+		} 
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating Method: " + mtd, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateFeatureAssignment(FeatureAssignment featAssign) {
+		try {
+			return unsafeValidator.validateFeatureAssignment(featAssign);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating FeatureAssignment: " + featAssign, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateFeatureInsert(FeatureInsert featInsert) {
+		try { 
+			return unsafeValidator.validateFeatureInsert(featInsert);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating FeatureInsert: " + featInsert, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateFeatureRemove(FeatureRemove featRemove) {
+		try {
+			return unsafeValidator.validateFeatureRemove(featRemove);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating FeatureRemove: " + featRemove, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateVariableAssignment(VariableAssignment varAssign) {
+		try {
+			return unsafeValidator.validateVariableAssignment(varAssign);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating VariableAssignment: " + varAssign, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateVariableDeclaration(VariableDeclaration varDecl) {
+		try {
+			return unsafeValidator.validateVariableDeclaration(varDecl);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating VariableDeclaration: " + varDecl, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateVariableInsert(VariableInsert varInsert) {
+		try {
+			return unsafeValidator.validateVariableInsert(varInsert);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating VariableInsert: " + varInsert, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateVariableRemove(VariableRemove varRemove) {
+		try {
+			return unsafeValidator.validateVariableRemove(varRemove);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating VariableRemove: " + varRemove, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateForEach(ForEach loop) {
+		try {
+			return unsafeValidator.validateForEach(loop);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating ForEach: " + loop, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateIf(If ifStmt) {
+		try {
+			return unsafeValidator.validateIf(ifStmt);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating If: " + ifStmt, e);
+			return emptyList();
+		}
+	}
+
+	public List<IValidationMessage> validateWhile(While loop) {
+		try {
+			return unsafeValidator.validateWhile(loop);
+		}
+		catch (Exception e) {
+			Activator.error("An internal error occurred while validating While: " + loop, e);
+			return emptyList();
+		}
+	}
+	
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -53,7 +53,6 @@ import org.eclipse.emf.ecoretools.ale.implementation.VariableDeclaration;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableInsert;
 import org.eclipse.emf.ecoretools.ale.implementation.VariableRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.While;
-import org.eclipse.osgi.service.environment.EnvironmentInfo;
 
 import com.google.common.base.Objects;
 
@@ -119,19 +118,21 @@ public class TypeValidator implements IValidator {
 			msgs.add(messages.extendingItself(xtdClass));
 		}
 		EClass baseCls = xtdClass.getBaseClass();
-		EList<EClass> superTypes = baseCls.getESuperTypes();
-		
-		List<EClass> extendsBaseClasses =
-				xtdClass
-				.getExtends()
-				.stream()
-				.map(xtd -> xtd.getBaseClass())
-				.collect(toList());
-		
-		extendsBaseClasses.stream()
-						  .filter(noneOf(superTypes, baseCls))
-						  .map(superBase -> messages.indirectExtension(xtdClass, superBase, baseCls))
-						  .forEach(msgs::add);
+		if (baseCls != null) {
+			EList<EClass> superTypes = baseCls.getESuperTypes();
+			
+			List<EClass> extendsBaseClasses =
+					xtdClass
+					.getExtends()
+					.stream()
+					.map(xtd -> xtd.getBaseClass())
+					.collect(toList());
+			
+			extendsBaseClasses.stream()
+							  .filter(noneOf(superTypes, baseCls))
+							  .map(superBase -> messages.indirectExtension(xtdClass, superBase, baseCls))
+							  .forEach(msgs::add);
+		}
 		return msgs;
 	}
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
@@ -186,6 +186,8 @@ public final class AstLookup implements IAstLookup {
 			env.getBehaviors().getParsedFiles()
 			.stream()
 			.flatMap(m -> m.getRoot().getClassExtensions().stream())
+			// base class can be null when X match no existing class in "open class X"
+			.filter(xtdCls -> xtdCls.getBaseClass() != null)
 			.filter(xtdCls -> xtdCls.getBaseClass().isSuperTypeOf(realType))
 			.collect(Collectors.toList());
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Export-Package: org.eclipse.emf.ecoretools,
  org.eclipse.emf.ecoretools.parser.antlr.internal,
  org.eclipse.emf.ecoretools.formatting2
 Import-Package: org.apache.log4j
+Bundle-Activator: org.eclipse.emf.ecoretools.AleXtextPlugin

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/AleXtextPlugin.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/AleXtextPlugin.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.emf.ecoretools;
+
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
+import org.osgi.framework.BundleContext;
+
+public class AleXtextPlugin extends Plugin {
+	
+	public static final String PLUGIN_ID = "org.eclipse.emf.ecoretools.ale.xtext";
+
+	// The shared instance
+	private static AleXtextPlugin plugin;
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
+
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 * 
+	 * @return the shared instance
+	 */
+	public static AleXtextPlugin getDefault() {
+		return plugin;
+	}
+
+	public static void warn(String msg, Throwable e) {
+		AleXtextPlugin.getDefault().getLog().log(new Status(Status.WARNING, PLUGIN_ID, Status.OK, msg, e));
+	}
+
+	public static void error(String msg, Throwable e) {
+		AleXtextPlugin.getDefault().getLog().log(new Status(Status.ERROR, PLUGIN_ID, Status.OK, msg, e));
+	}
+	
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
@@ -29,6 +29,7 @@ import org.eclipse.xtext.nodemodel.impl.HiddenLeafNode
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.validation.Check
 import org.eclipse.emf.ecoretools.ale.core.env.impl.FileBasedAleEnvironment
+import org.eclipse.emf.ecoretools.AleXtextPlugin
 
 /**
  * Delegate validation to ALE validator
@@ -75,7 +76,18 @@ class AleValidator extends AbstractAleValidator {
 				marker.setAttribute(IMarker.CHAR_END, msg.endPosition);
 			]
 		}
-		finally {dsl.close}
+		catch (Exception e) {
+			val marker = aleFile.createMarker(ALE_MARKER)
+			marker.setAttribute(IMarker.MESSAGE, "An internal error occurred while validating the file: " + e.message)
+			marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR)
+			marker.setAttribute(IMarker.CHAR_START, 0)
+			marker.setAttribute(IMarker.CHAR_END, 0)
+			
+			AleXtextPlugin.error("An internal error occurred while validating " + aleFile, e)
+		}
+		finally {
+			dsl.close()
+		}
 		
 	}
 	

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/validation/openingEnum.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/validation/openingEnum.implem
@@ -1,0 +1,10 @@
+behavior openEnum;
+
+open class MyEnum {
+
+	@main
+	def void main() {
+		String str := self;
+	}
+
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/model/test.ecore
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/model/test.ecore
@@ -9,4 +9,5 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="children" upperBound="-1"
         eType="#//ClassA" containment="true"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="MyEnum"/>
 </ecore:EPackage>

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/OpenClassValidationTest.java
@@ -120,4 +120,16 @@ public class OpenClassValidationTest {
 		assertTrue("Opening a locally defined class should not raise any error", msg.isEmpty());
 	}
 	
+	@Test
+	public void testOpeningEnumShouldShowAnError() {
+		env = IAleEnvironment.fromPaths(asList("model/test.ecore"),asList("input/validation/openingEnum.implem"));
+		ALEValidator validator = new ALEValidator(env);
+		validator.validate(env.getBehaviors().getParsedFiles());
+		List<IValidationMessage> msg = validator.getMessages();
+		
+		assertEquals(2, msg.size());
+		assertMsgEquals(ValidationMessageLevel.ERROR, 22, 39, "Cannot open \"MyEnum\": make sure it is an EClass (an not e.g. an EEnum)", msg.get(0));
+		assertMsgEquals(ValidationMessageLevel.ERROR, 75, 93, "Type mismatch: cannot assign [implementation::UnresolvedEClassifier] to [ecore::EString]", msg.get(1));
+	}
+	
 }


### PR DESCRIPTION
Fix #149.

The CI pass and everything looks good to me. I'll make a last check on GEMOC Studio then proceed to merge the PR.

## Changes

 - validators are now decorated with `SafeValidator` which ensures that exceptions thrown by validation methods are caught, logged then discard to continue the validation
 - the case where `ExtendedClass::getBaseClass` returns has been handled and shouldn't cause errors anymore
 - if an internal error still occurs during validation but outside validators then `AleValidator` will catch it and log it