### PR TITLE
[Interpreter] Prevent internal errors when looking up attribute of a class without a base class

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/notapi/DynamicFeatureRegistry.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/notapi/DynamicFeatureRegistry.java
@@ -204,7 +204,7 @@ public class DynamicFeatureRegistry {
 	}
 	
 	/**
-	 * returns the first feature in the extended class hieararchy that applies to this type that declares a feature with this name
+	 * returns the first feature in the extended class hierarchy that applies to this type that declares a feature with this name
 	 * @param type
 	 * @param featureName
 	 * @return
@@ -214,6 +214,7 @@ public class DynamicFeatureRegistry {
 		List<ExtendedClass> extendedClasses = allImplemModels
 			.stream()
 			.flatMap(m -> m.getClassExtensions().stream())
+			.filter(cls -> cls.getBaseClass() != null)
 			.filter(cls -> cls.getBaseClass().isSuperTypeOf(type)).collect(Collectors.toList());
 		for(ExtendedClass extendedClass : extendedClasses) {
 			Optional<Attribute> featureDeclaration = extendedClass.getAttributes().stream()

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/validation/AleEditorMessages.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/validation/AleEditorMessages.java
@@ -63,6 +63,11 @@ public final class AleEditorMessages extends NLS {
     public static String RESULT_RESERVED;
     public static String EXTENDING_ITSELF;
     public static String METHOD_ALREADY_DEFINED;
+    public static String INTERNAL_ERROR;
+    
+    public static String internalError(String message) {
+    	return MessageFormat.format(INTERNAL_ERROR, message);
+    }
     
     public static String assignIllegal(String valueTypes, String variableTypes, String expectedTypes) {
     	return MessageFormat.format(ASSIGN_ILLEGAL, valueTypes, variableTypes, expectedTypes);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/validation/EditorMarkerFormatter.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/validation/EditorMarkerFormatter.java
@@ -135,9 +135,14 @@ public final class EditorMarkerFormatter extends DiagnosticsSwitch<String> imple
 	}
 
 	@Override
-	public String caseInternalError(InternalError object) {
-		// TODO Auto-generated method stub
-		return super.caseInternalError(object);
+	public String caseInternalError(InternalError error) {
+		if (error.getMessage() != null) {
+			return AleEditorMessages.internalError(error.getMessage());
+		}
+		if (error.getCause() != null && error.getCause().getMessage() != null) {
+			return AleEditorMessages.internalError(error.getCause().getMessage());
+		}
+		return AleEditorMessages.internalError("unknown error");
 	}
 
 	@Override

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/validation/ale_editor_messages.properties
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/validation/ale_editor_messages.properties
@@ -49,3 +49,5 @@ SELF_RESERVED = 'self' is a reserved name
 RESULT_RESERVED = 'result' is a reserved name
 
 EXTENDING_ITSELF = Reopened {0} is extending itself
+
+INTERNAL_ERROR = An internal error occurred during validation, please report

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleValidator.xtend
@@ -72,6 +72,8 @@ class AleValidator extends AbstractAleValidator {
 			validator.validate(parsedSemantics);
 			val List<Message> msgs = validator.getMessages();
 			
+			logInternalErrors(aleFile, msgs)
+			
 			val markerFactory = new DiagnosticsToEditorMarkerAdapter([ str | aleFile.createMarker(str) ], new EditorMarkerFormatter(new TypeChecker(null, env.context)))
 			
 			msgs.filter[ msg |
@@ -132,6 +134,11 @@ class AleValidator extends AbstractAleValidator {
 			messageAcceptor.acceptError("Extra space in " + message, grammarElement,
 				keywordNode.endOffset, keywordNode.nextSibling.length, "")
 		}
+	}
+	
+	private static def void logInternalErrors(IFile aleFile, List<Message> messages) {
+		messages.filter(typeof(InternalError))
+				.forEach[ internalError | AleXtextPlugin.error("An internal error occurred during validation of " + aleFile.fullPath, internalError.cause)]
 	}
 	
 	// copied from WorkbenchDsl (which introduce cyclic dependency if used)


### PR DESCRIPTION
Also related to #149.

## Because
 - a class might not have a base class (e.g. when attempting to open a EEnum)

## Changes
 - `DynamicFeatureRegistry` takes this case into account
 - `BaseValidator` properly reports internal errors instead of printing them to the console
 - `AleValidator` logs internal errors to ease debug
 - `EditorMarkerFormatter` shows internal error markers on the editor to spotlight them