### PR TITLE
Handle overridden methods & show AQL errors as markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#67](https://github.com/gemoc/ale-lang/issues/67) `Sequence` values can be assigned to variables which type is `OrderedSet` and vice versa
 - [#70](https://github.com/gemoc/ale-lang/issues/70) Paths to ALE resources (in _.dsl_ files and projects' preferences) are not updated when the project is renamed
 - [#102](https://github.com/gemoc/ale-lang/issues/102) The editor shows an error when a method is used to define the range of a for-each loop
+- [#119](https://github.com/gemoc/ale-lang/issues/119) Cannot override static EOperations from a subclass
 - [#120](https://github.com/gemoc/ale-lang/issues/120) The `+=` operator cannot be used to concatenate two collections
 - [#126](https://github.com/gemoc/ale-lang/issues/126) The interpreter evaluates an expression even if a subexpression produces an error
 - [#128](https://github.com/gemoc/ale-lang/issues/128) The interpreter allows to concatenate heterogeneous collections

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.ecore
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.ecore
@@ -151,4 +151,5 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="UnresolvedEClassifier"/>
+  <eClassifiers xsi:type="ecore:EDataType" name="VoidEClassifier" instanceClassName="java.lang.Void"/>
 </ecore:EPackage>

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.genmodel
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/model/Implementation.genmodel
@@ -10,6 +10,7 @@
   <foreignModel>Implementation.ecore</foreignModel>
   <genPackages prefix="Implementation" basePackage="org.eclipse.emf.ecoretools.ale"
       disposableProviderFactory="true" ecorePackage="Implementation.ecore#/">
+    <genDataTypes ecoreDataType="Implementation.ecore#//VoidEClassifier"/>
     <genClasses ecoreClass="Implementation.ecore#//ModelBehavior">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Implementation.ecore#//ModelBehavior/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Implementation.ecore#//ModelBehavior/units"/>

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/ImplementationPackage.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/ImplementationPackage.java
@@ -14,6 +14,7 @@ package org.eclipse.emf.ecoretools.ale.implementation;
 import org.eclipse.acceleo.query.ast.AstPackage;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
@@ -1490,6 +1491,17 @@ public interface ImplementationPackage extends EPackage {
 
 
 	/**
+	 * The meta object id for the '<em>Void EClassifier</em>' data type.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see java.lang.Void
+	 * @see org.eclipse.emf.ecoretools.ale.implementation.impl.ImplementationPackageImpl#getVoidEClassifier()
+	 * @generated
+	 */
+	int VOID_ECLASSIFIER = 26;
+
+
+	/**
 	 * Returns the meta object for class '{@link org.eclipse.emf.ecoretools.ale.implementation.ModelBehavior <em>Model Behavior</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2300,6 +2312,17 @@ public interface ImplementationPackage extends EPackage {
 	EClass getUnresolvedEClassifier();
 
 	/**
+	 * Returns the meta object for data type '{@link java.lang.Void <em>Void EClassifier</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for data type '<em>Void EClassifier</em>'.
+	 * @see java.lang.Void
+	 * @model instanceClass="java.lang.Void"
+	 * @generated
+	 */
+	EDataType getVoidEClassifier();
+
+	/**
 	 * Returns the factory that creates the instances of the model.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2981,6 +3004,16 @@ public interface ImplementationPackage extends EPackage {
 		 * @generated
 		 */
 		EClass UNRESOLVED_ECLASSIFIER = eINSTANCE.getUnresolvedEClassifier();
+
+		/**
+		 * The meta object literal for the '<em>Void EClassifier</em>' data type.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see java.lang.Void
+		 * @see org.eclipse.emf.ecoretools.ale.implementation.impl.ImplementationPackageImpl#getVoidEClassifier()
+		 * @generated
+		 */
+		EDataType VOID_ECLASSIFIER = eINSTANCE.getVoidEClassifier();
 
 	}
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationFactoryImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationFactoryImpl.java
@@ -12,6 +12,7 @@
 package org.eclipse.emf.ecoretools.ale.implementation.impl;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 
@@ -99,6 +100,36 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 			case ImplementationPackage.UNRESOLVED_ECLASSIFIER: return createUnresolvedEClassifier();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object createFromString(EDataType eDataType, String initialValue) {
+		switch (eDataType.getClassifierID()) {
+			case ImplementationPackage.VOID_ECLASSIFIER:
+				return createVoidEClassifierFromString(eDataType, initialValue);
+			default:
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String convertToString(EDataType eDataType, Object instanceValue) {
+		switch (eDataType.getClassifierID()) {
+			case ImplementationPackage.VOID_ECLASSIFIER:
+				return convertVoidEClassifierToString(eDataType, instanceValue);
+			default:
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
 	}
 
@@ -375,6 +406,24 @@ public class ImplementationFactoryImpl extends EFactoryImpl implements Implement
 	public UnresolvedEClassifier createUnresolvedEClassifier() {
 		UnresolvedEClassifierImpl unresolvedEClassifier = new UnresolvedEClassifierImpl();
 		return unresolvedEClassifier;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public Void createVoidEClassifierFromString(EDataType eDataType, String initialValue) {
+		return (Void)super.createFromString(eDataType, initialValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String convertVoidEClassifierToString(EDataType eDataType, Object instanceValue) {
+		return super.convertToString(eDataType, instanceValue);
 	}
 
 	/**

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationPackageImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/implementation/impl/ImplementationPackageImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.acceleo.query.ast.AstPackage;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
@@ -245,6 +246,13 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * @generated
 	 */
 	private EClass unresolvedEClassifierEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EDataType voidEClassifierEDataType = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -1077,6 +1085,16 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 	 * @generated
 	 */
 	@Override
+	public EDataType getVoidEClassifier() {
+		return voidEClassifierEDataType;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public ImplementationFactory getImplementationFactory() {
 		return (ImplementationFactory)getEFactoryInstance();
 	}
@@ -1201,6 +1219,9 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 		createEReference(caseEClass, CASE__VALUE);
 
 		unresolvedEClassifierEClass = createEClass(UNRESOLVED_ECLASSIFIER);
+
+		// Create data types
+		voidEClassifierEDataType = createEDataType(VOID_ECLASSIFIER);
 	}
 
 	/**
@@ -1359,6 +1380,9 @@ public class ImplementationPackageImpl extends EPackageImpl implements Implement
 		initEReference(getCase_Value(), theAstPackage.getExpression(), null, "value", null, 1, 1, Case.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(unresolvedEClassifierEClass, UnresolvedEClassifier.class, "UnresolvedEClassifier", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+
+		// Initialize data types
+		initEDataType(voidEClassifierEDataType, Void.class, "VoidEClassifier", IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);
 
 		// Create resource
 		createResource(eNS_URI);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/MethodEvaluator.java
@@ -717,7 +717,6 @@ public class MethodEvaluator {
 	 * Validates an Expression and stored its types in the current scope.
 	 */
 	private Set<IType> validateAndStoreType(Expression expression) throws CriticalFailureException {
-		// FIXME [Validation] Should do something with validation.getMessages()
 		IValidationResult validation = validate(expression);
 		Set<IType> inferredTypes = validation.getPossibleTypes(expression);
 		inferredTypes = inferredTypes == null ? new HashSet<>() : inferredTypes;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/MethodEvaluator.java
@@ -72,6 +72,7 @@ import org.eclipse.emf.ecoretools.ale.implementation.FeaturePut;
 import org.eclipse.emf.ecoretools.ale.implementation.FeatureRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
 import org.eclipse.emf.ecoretools.ale.implementation.If;
+import org.eclipse.emf.ecoretools.ale.implementation.ImplementationPackage;
 import org.eclipse.emf.ecoretools.ale.implementation.Method;
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.emf.ecoretools.ale.implementation.Statement;
@@ -175,7 +176,8 @@ public class MethodEvaluator {
 			methodScope.putValue("self", target);
 			methodScope.putTypes("self", newHashSet(convert.toAQL(target.eClass())));
 			
-			boolean isVoidMethod = operation.getOperationRef().getEType() == null;
+			boolean isVoidMethod = operation.getOperationRef().getEType() == null 
+								|| operation.getOperationRef().getEType() == ImplementationPackage.eINSTANCE.getVoidEClassifier();
 			if (!isVoidMethod) {
 				methodScope.putTypes("result", newHashSet(convert.toAQL(operation.getOperationRef())));
 			}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToAleBehaviorsFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToAleBehaviorsFactory.java
@@ -204,6 +204,9 @@ public class AntlrAstToAleBehaviorsFactory {
 		newMethod.setBody(body);
 		newMethod.getTags().addAll(tags);
 		
+		if (operation != null && operation.getEType() == null) {
+//			operation.setEType(ImplementationPackage.eINSTANCE.getVoidEClassifier());
+		}
 		return newMethod;
 	}
 	
@@ -577,7 +580,7 @@ public class AntlrAstToAleBehaviorsFactory {
 			case "float" 	: return EcorePackage.eINSTANCE.getEFloat();
 			case "double" 	: return EcorePackage.eINSTANCE.getEDouble();
 			case "Double"   : return EcorePackage.eINSTANCE.getEDouble();
-			case "void"		: return null;
+			case "void"		: return ImplementationPackage.eINSTANCE.getVoidEClassifier();
 			default			: return ImplementationPackage.eINSTANCE.getUnresolvedEClassifier();
 		}
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToAleBehaviorsFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToAleBehaviorsFactory.java
@@ -527,12 +527,13 @@ public class AntlrAstToAleBehaviorsFactory {
 	//Can return null
 	public Optional<EOperation> resolve(String className, String methodName, int nbArgs, RTypeContext returnType) {
 		EClassifier type = resolve(returnType).getEType();
-		//TODO: manage qualified name		
+		// FIXME: manage qualified name		
 		return qryEnv.getEPackageProvider()
 					 .getEClassifiers().stream()
 					 .filter(cls -> cls instanceof EClass)
+					 .map(EClass.class::cast)
 					 .filter(cls -> cls.getName().equals(className))
-					 .flatMap(cls -> ((EClass)cls).getEOperations().stream())
+					 .flatMap(cls -> cls.getEAllOperations().stream())
 					 .filter(op -> op.getName().equals(methodName) && op.getEParameters().size() == nbArgs && op.getEType() == type)
 					 .findFirst();
 	}

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToBehaviorsAstAdapter.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/internal/AntlrAstToBehaviorsAstAdapter.java
@@ -20,9 +20,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.acceleo.query.runtime.IQueryEnvironment;
+import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EAnnotation;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/NameValidator.java
@@ -53,6 +53,7 @@ import org.eclipse.emf.ecoretools.ale.implementation.FeatureInsert;
 import org.eclipse.emf.ecoretools.ale.implementation.FeatureRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
 import org.eclipse.emf.ecoretools.ale.implementation.If;
+import org.eclipse.emf.ecoretools.ale.implementation.ImplementationPackage;
 import org.eclipse.emf.ecoretools.ale.implementation.Method;
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.emf.ecoretools.ale.implementation.RuntimeClass;
@@ -594,7 +595,8 @@ public class NameValidator implements IValidator {
 				// Check attempts to assign 'result' in a void operation
 				
 				boolean assigningToResult = "result".equals(varAssign.getName());
-				boolean isVoidOperation = enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null;
+				boolean isVoidOperation = (enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null)
+									   || enclosingOperation.getEType() == ImplementationPackage.eINSTANCE.getVoidEClassifier();
 				if(assigningToResult && isVoidOperation) {
 					Message invalidAssignment = messages.assignmentToResultInVoidOperation(varAssign);
 					msgs.add(invalidAssignment);
@@ -691,7 +693,8 @@ public class NameValidator implements IValidator {
 			EOperation enclosingOperation = method.getOperationRef();
 			
 			if (enclosingOperation != null) {
-				boolean isVoidOperation = enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null;
+				boolean isVoidOperation = (enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null)
+									   || enclosingOperation.getEType() == ImplementationPackage.eINSTANCE.getVoidEClassifier();
 				if(isVoidOperation) {
 					Message invalidAssignment = messages.assignmentToResultInVoidOperation(varInsert);
 					msgs.add(invalidAssignment);
@@ -731,7 +734,8 @@ public class NameValidator implements IValidator {
 			EOperation enclosingOperation = method.getOperationRef();
 			
 			if (enclosingOperation != null) {
-				boolean isVoidOperation = enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null;
+				boolean isVoidOperation = (enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null)
+						   				|| enclosingOperation.getEType() == ImplementationPackage.eINSTANCE.getVoidEClassifier();
 				if(isVoidOperation) {
 					Message invalidAssignment = messages.assignmentToResultInVoidOperation(varRemove);
 					msgs.add(invalidAssignment);

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/TypeValidator.java
@@ -46,6 +46,7 @@ import org.eclipse.emf.ecoretools.ale.implementation.FeatureInsert;
 import org.eclipse.emf.ecoretools.ale.implementation.FeatureRemove;
 import org.eclipse.emf.ecoretools.ale.implementation.ForEach;
 import org.eclipse.emf.ecoretools.ale.implementation.If;
+import org.eclipse.emf.ecoretools.ale.implementation.ImplementationPackage;
 import org.eclipse.emf.ecoretools.ale.implementation.Method;
 import org.eclipse.emf.ecoretools.ale.implementation.ModelUnit;
 import org.eclipse.emf.ecoretools.ale.implementation.RuntimeClass;
@@ -385,7 +386,8 @@ public class TypeValidator implements IValidator {
 			// Assignment outside of a method, should never happen
 			return PROBLEM_HANDLED_BY_ANOTHER_VALIDATOR;
 		}
-		boolean isVoidOperation = enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null;
+		boolean isVoidOperation = (enclosingOperation.getEType() == null && enclosingOperation.getEGenericType() == null)
+							   || enclosingOperation.getEType() == ImplementationPackage.eINSTANCE.getVoidEClassifier();
 		if(isVoidOperation) {
 			// A void operation should not return anything but this is handled by the NameValidator
 			return PROBLEM_HANDLED_BY_ANOTHER_VALIDATOR;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/AstLookup.java
@@ -134,13 +134,15 @@ public final class AstLookup implements IAstLookup {
 			// Look at enclosing method's parameters
 			else if (currentScope instanceof Method) {
 				Method method = (Method) currentScope;
-				Optional<EParameter> parameter = method.getOperationRef()
-													   .getEParameters().stream()
-													   .filter(param -> param.getName().equals(variableName))
-													   .findFirst();
-				
-				if (parameter.isPresent()) {
-					declaredTypes.add(convert.toAQL(parameter.get()));
+				if (method.getOperationRef() != null) {
+					Optional<EParameter> parameter = method.getOperationRef()
+														   .getEParameters().stream()
+														   .filter(param -> param.getName().equals(variableName))
+														   .findFirst();
+					
+					if (parameter.isPresent()) {
+						declaredTypes.add(convert.toAQL(parameter.get()));
+					}
 				}
 			}
 			currentObject = currentScope;

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/validation/impl/ConvertType.java
@@ -78,7 +78,7 @@ public final class ConvertType implements IConvertType {
 			}
 			return new SequenceType(queryEnvironment, collectionType);
 		}
-		if(type == null) {
+		if(type == null || type == ImplementationPackage.eINSTANCE.getVoidEClassifier()) {
 			return new NothingType("void");
 		}
 		return new EClassifierType(queryEnvironment, type);

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/parser/BuildTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/parser/BuildTest.java
@@ -144,7 +144,7 @@ public class BuildTest {
 		EOperation eOperationDef = method.getOperationRef();
 		assertNotNull(eOperationDef);
 		assertEquals("fooBar",eOperationDef.getName());
-		assertNull(eOperationDef.getEType());
+		assertEquals(ImplementationPackage.eINSTANCE.getVoidEClassifier(), eOperationDef.getEType());
 		assertEquals(2, eOperationDef.getEParameters().size());
 		assertEquals("param1", eOperationDef.getEParameters().get(0).getName());
 		assertEquals(EcorePackage.eINSTANCE.getEObject(), eOperationDef.getEParameters().get(0).getEType());
@@ -234,7 +234,7 @@ public class BuildTest {
 		EOperation eOperationDef = method.getOperationRef();
 		assertNotNull(eOperationDef);
 		assertEquals("entryPoint",eOperationDef.getName());
-		assertNull(eOperationDef.getEType());
+		assertEquals(ImplementationPackage.eINSTANCE.getVoidEClassifier(), eOperationDef.getEType());
 		assertEquals(1, eOperationDef.getEParameters().size());
 		assertEquals("arg", eOperationDef.getEParameters().get(0).getName());
 		assertEquals(EcorePackage.eINSTANCE.getEInt(), eOperationDef.getEParameters().get(0).getEType());
@@ -340,7 +340,7 @@ public class BuildTest {
 		EOperation eOperationDef = method.getOperationRef();
 		assertNotNull(eOperationDef);
 		assertEquals("entryPoint",eOperationDef.getName());
-		assertNull(eOperationDef.getEType());
+		assertEquals(ImplementationPackage.eINSTANCE.getVoidEClassifier(), eOperationDef.getEType());
 		assertEquals(1, eOperationDef.getEParameters().size());
 		assertEquals("arg", eOperationDef.getEParameters().get(0).getName());
 		assertEquals(EcorePackage.eINSTANCE.getEInt(), eOperationDef.getEParameters().get(0).getEType());
@@ -383,7 +383,7 @@ public class BuildTest {
 		EOperation eOperationDef = method.getOperationRef();
 		assertNotNull(eOperationDef);
 		assertEquals("entryPoint",eOperationDef.getName());
-		assertNull(eOperationDef.getEType());
+		assertEquals(ImplementationPackage.eINSTANCE.getVoidEClassifier(), eOperationDef.getEType());
 		assertEquals(1, eOperationDef.getEParameters().size());
 		assertEquals("arg", eOperationDef.getEParameters().get(0).getName());
 		assertEquals(EcorePackage.eINSTANCE.getEInt(), eOperationDef.getEParameters().get(0).getEType());
@@ -455,7 +455,7 @@ public class BuildTest {
 		EOperation eOperationDef = ((Method)method).getOperationRef();
 		assertNotNull(eOperationDef);
 		assertEquals("entryPoint",eOperationDef.getName());
-		assertNull(eOperationDef.getEType());
+		assertEquals(ImplementationPackage.eINSTANCE.getVoidEClassifier(), eOperationDef.getEType());
 		assertEquals(1, eOperationDef.getEParameters().size());
 		assertEquals("arg", eOperationDef.getEParameters().get(0).getName());
 		assertEquals(EcorePackage.eINSTANCE.getEInt(), eOperationDef.getEParameters().get(0).getEType());
@@ -877,7 +877,7 @@ public class BuildTest {
 		EOperation eOperationDef = method.getOperationRef();
 		assertNotNull(eOperationDef);
 		assertEquals("main",eOperationDef.getName());
-		assertEquals(null,eOperationDef.getEType());
+		assertEquals(ImplementationPackage.eINSTANCE.getVoidEClassifier(), eOperationDef.getEType());
 		assertEquals(0, eOperationDef.getEParameters().size());
 		
 		Block body = ((Method)method).getBody();
@@ -920,7 +920,7 @@ public class BuildTest {
 		EOperation eOperationDef = method.getOperationRef();
 		assertNotNull(eOperationDef);
 		assertEquals("main",eOperationDef.getName());
-		assertEquals(null,eOperationDef.getEType());
+		assertEquals(ImplementationPackage.eINSTANCE.getVoidEClassifier(), eOperationDef.getEType());
 		assertEquals(0, eOperationDef.getEParameters().size());
 		
 		Block body = ((Method)method).getBody();

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/validation/test/NameValidatorTest.java
@@ -743,7 +743,7 @@ public class NameValidatorTest {
 		validator.validate(env.getBehaviors().getParsedFiles());
 		List<Message> msg = validator.getMessages();
 		
-		assertEquals(3, msg.size());
+		assertEquals(msg.toString(), 3, msg.size());
 		assertMsgEquals(env, ValidationMessageLevel.ERROR, 65, 76, "'result' is not available in a void method. Change method's return type", msg.get(0));
 		assertMsgEquals(env, ValidationMessageLevel.ERROR, 80, 91, "'result' is not available in a void method. Change method's return type", msg.get(1));
 		assertMsgEquals(env, ValidationMessageLevel.ERROR, 95, 106, "'result' is not available in a void method. Change method's return type", msg.get(2));


### PR DESCRIPTION
Closes #119 
Closes #165 

Make sure Acceleo errors are shown as markers & prevent errors when overridding method from a parent class.