### PR TITLE
[Editor] Add tooltips when open class/behavior are hovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#129](https://github.com/gemoc/ale-lang/pull/129) The editor warns when the `+=` and `-=` operators ared used on the `result` variable in a void method
 - [#131](https://github.com/gemoc/ale-lang/pull/131) The editor autocompletes attributes and methods of local variables and method parameters (support limited to model instances)
 - [#169](https://github.com/gemoc/ale-lang/pull/169) The editor shows documentation about the _open_ and _behavior_ keywords on hover
+- [#169](https://github.com/gemoc/ale-lang/pull/169) The editor shows the fully qualified name of an open class on hover as well as information about its EPackage
 
 ### Changed
 - [#93](https://github.com/gemoc/ale-lang/issues/93) More tokens are available to tailor editor's syntax coloring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The interpreter can be run by right-clicking on an ALE project
 - [#129](https://github.com/gemoc/ale-lang/pull/129) The editor warns when the `+=` and `-=` operators ared used on the `result` variable in a void method
 - [#131](https://github.com/gemoc/ale-lang/pull/131) The editor autocompletes attributes and methods of local variables and method parameters (support limited to model instances)
+- [#169](https://github.com/gemoc/ale-lang/pull/169) The editor shows documentation about the _open_ and _behavior_ keywords on hover
 
 ### Changed
 - [#93](https://github.com/gemoc/ale-lang/issues/93) More tokens are available to tailor editor's syntax coloring

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleUiModule.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/AleUiModule.xtend
@@ -4,8 +4,12 @@
 package org.eclipse.emf.ecoretools.ui
 
 import org.eclipse.emf.ecoretools.ui.contentassist.AleTemplateProposalProvider
+import org.eclipse.emf.ecoretools.ui.hover.AleDispatchingEObjectHover
+import org.eclipse.emf.ecoretools.ui.hover.AleHoverProvider
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.xtext.ui.editor.hover.IEObjectHover
+import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration
 
 /**
@@ -24,6 +28,14 @@ class AleUiModule extends AbstractAleUiModule {
 	
 	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
 		return typeof(AleSemanticHighlightingCalculator);
+	}
+	
+	override Class<? extends IEObjectHover> bindIEObjectHover() {
+		return typeof(AleDispatchingEObjectHover)
+	}
+	
+	def Class<? extends IEObjectHoverProvider> bindIEObjectHoverProvider() {
+	    return typeof(AleHoverProvider)
 	}
 	
 }

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/hover/AleDispatchingEObjectHover.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/hover/AleDispatchingEObjectHover.java
@@ -1,0 +1,71 @@
+package org.eclipse.emf.ecoretools.ui.hover;
+
+import static java.util.Arrays.asList;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.text.IInformationControlCreator;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Region;
+import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.hover.DispatchingEObjectTextHover;
+import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider;
+import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider.IInformationControlCreatorProvider;
+import org.eclipse.xtext.util.Pair;
+import org.eclipse.xtext.util.Tuples;
+
+import com.google.inject.Inject;
+
+public class AleDispatchingEObjectHover extends DispatchingEObjectTextHover {
+ 
+    @Inject
+    IEObjectHoverProvider hoverProvider;
+ 
+    IInformationControlCreatorProvider lastCreatorProvider = null;
+ 
+    @Override
+    public Object getHoverInfo(EObject first, ITextViewer textViewer, IRegion hoverRegion) {
+        if (first instanceof Keyword) {
+            lastCreatorProvider = hoverProvider.getHoverInfo(first, textViewer, hoverRegion);
+            return lastCreatorProvider == null ? null : lastCreatorProvider.getInfo();
+        }
+        lastCreatorProvider = null;
+        return super.getHoverInfo(first, textViewer, hoverRegion);
+    }
+ 
+    @Override
+    public IInformationControlCreator getHoverControlCreator() {
+        return this.lastCreatorProvider == null ? super.getHoverControlCreator() : lastCreatorProvider.getHoverControlCreator();
+    }
+ 
+    @Override
+    protected Pair<EObject, IRegion> getXtextElementAt(XtextResource resource, final int offset) {
+        Pair<EObject, IRegion> result = super.getXtextElementAt(resource, offset);
+        if (result == null) {
+            result = resolveKeywordAt(resource, offset);
+        }
+        return result;
+    }
+
+	private static Pair<EObject, IRegion> resolveKeywordAt(XtextResource resource, int offset) {
+		IParseResult parseResult = resource.getParseResult();
+		if (parseResult != null) {
+			ILeafNode leaf = NodeModelUtils.findLeafNodeAtOffset(parseResult.getRootNode(), offset);
+			if (leaf != null && leaf.isHidden() && leaf.getOffset() == offset) {
+				leaf = NodeModelUtils.findLeafNodeAtOffset(parseResult.getRootNode(), offset - 1);
+			}
+			if (leaf != null && leaf.getGrammarElement() instanceof Keyword) {
+				Keyword keyword = (Keyword) leaf.getGrammarElement();
+				if (asList("open", "behavior").contains(keyword.getValue())) {
+					return Tuples.create((EObject) keyword, (IRegion) new Region(leaf.getOffset(), leaf.getLength()));
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/hover/AleHoverProvider.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/hover/AleHoverProvider.java
@@ -1,0 +1,49 @@
+package org.eclipse.emf.ecoretools.ui.hover;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.internal.text.html.HTMLPrinter;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.ui.editor.hover.html.DefaultEObjectHoverProvider;
+import org.eclipse.xtext.ui.editor.hover.html.XtextBrowserInformationControlInput;
+
+public class AleHoverProvider extends DefaultEObjectHoverProvider {
+
+	@Override
+	protected XtextBrowserInformationControlInput getHoverInfo(EObject obj, IRegion region, XtextBrowserInformationControlInput prev) {
+		if (obj instanceof Keyword) {
+			String html = getHoverInfoAsHtml(obj);
+			if (html != null) {
+				StringBuffer buffer = new StringBuffer(html);
+				HTMLPrinter.insertPageProlog(buffer, 0, getStyleSheet());
+				HTMLPrinter.addPageEpilog(buffer);
+				return new XtextBrowserInformationControlInput(prev, obj, buffer.toString(), getLabelProvider());
+			}
+		}
+		return super.getHoverInfo(obj, region, prev);
+	}
+
+	@Override
+	protected String getHoverInfoAsHtml(EObject o) {
+		if (o instanceof Keyword) {
+			return hoverText((Keyword) o);
+		}
+		return super.getHoverInfoAsHtml(o);
+	}
+	
+	private static String hoverText(Keyword keyword) {
+		if (keyword.getValue().equals("open")) {
+			return "Opens a class already defined in an Ecore model to add new attributes or methods";
+		}
+		else if (keyword.getValue().equals("behavior")) {
+			return "Defines a new semantic module. <br/>"
+				 + "<br/>"
+				 + "The name that follows is the name of the new EPackage "
+				 + "that will be created to contain the dynamic classes defined with the <code>class</code> keyword.";
+		}
+		else {
+			return "";
+		}
+	}
+
+}

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/hover/AleHoverProvider.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext.ui/src/org/eclipse/emf/ecoretools/ui/hover/AleHoverProvider.java
@@ -1,6 +1,17 @@
 package org.eclipse.emf.ecoretools.ui.hover;
 
+import static java.util.stream.Collectors.joining;
+import static org.eclipse.emf.ecoretools.ale.core.validation.QualifiedNames.getQualifiedName;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecoretools.ale.Unit;
+import org.eclipse.emf.ecoretools.ale.core.env.IAleEnvironment;
+import org.eclipse.emf.ecoretools.ale.ide.project.IAleProject;
+import org.eclipse.emf.ecoretools.ale.implementation.ExtendedClass;
+import org.eclipse.emf.workspace.util.WorkspaceSynchronizer;
 import org.eclipse.jface.internal.text.html.HTMLPrinter;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.xtext.Keyword;
@@ -24,13 +35,30 @@ public class AleHoverProvider extends DefaultEObjectHoverProvider {
 	}
 
 	@Override
-	protected String getHoverInfoAsHtml(EObject o) {
-		if (o instanceof Keyword) {
-			return hoverText((Keyword) o);
+	protected String getHoverInfoAsHtml(EObject hovered) {
+		if (hovered instanceof Keyword) {
+			return hoverText((Keyword) hovered);
 		}
-		return super.getHoverInfoAsHtml(o);
+		else if (hovered instanceof org.eclipse.emf.ecoretools.ale.ExtendedClass) {
+			org.eclipse.emf.ecoretools.ale.ExtendedClass extendedClass = (org.eclipse.emf.ecoretools.ale.ExtendedClass) hovered;
+			IFile aleFile = WorkspaceSynchronizer.getFile(hovered.eResource());
+			IAleEnvironment environment = IAleProject.from(aleFile.getProject()).getEnvironment();
+			return environment.getBehaviors()
+							  .findClass(extendedClass.getName())
+							  .filter(ExtendedClass.class::isInstance)
+							  .map(ExtendedClass.class::cast)
+							  .map(cls -> hoverText(environment, cls))
+							  .orElse("unresolved class");
+		}
+		else if (hovered instanceof Unit) {
+			Unit unit = (Unit) hovered;
+			IFile aleFile = WorkspaceSynchronizer.getFile(hovered.eResource());
+			IAleEnvironment environment = IAleProject.from(aleFile.getProject()).getEnvironment();
+			return hoverText(environment, unit);
+		}
+		return super.getHoverInfoAsHtml(hovered);
 	}
-	
+
 	private static String hoverText(Keyword keyword) {
 		if (keyword.getValue().equals("open")) {
 			return "Opens a class already defined in an Ecore model to add new attributes or methods";
@@ -44,6 +72,31 @@ public class AleHoverProvider extends DefaultEObjectHoverProvider {
 		else {
 			return "";
 		}
+	}
+	
+	private static String hoverText(IAleEnvironment env, ExtendedClass cls) {
+		if (cls.getBaseClass() == null) {
+			return "unresolved class '" + cls.getName() + "'<br/>"
+				 + "<br/>"
+				 + "The following EPackage are currently registered:<br/>"
+				 + env.getMetamodels().stream()
+				 	  .map(pkg -> "<li>" + pkg.getName() + " (nsPrefix:" + pkg.getNsPrefix() + ", nsURI: " + pkg.getNsURI() + ")</il>")
+					  .collect(joining("", "<ul>", "</ul>"));
+		}
+		else {
+			EClass openClass = cls.getBaseClass();
+			EPackage pkg = openClass.getEPackage();
+			return "<b>Opening:</b> " + getQualifiedName(openClass) + "<br/>"
+				 + "<br/>"
+				 + "<b>EPackage:</b> " + pkg.getName() + " (nsPrefix:" + pkg.getNsPrefix() + ", nsURI: " + pkg.getNsURI() + ")";
+		}
+	}
+	
+	private static String hoverText(IAleEnvironment environment, Unit unit) {
+		return "Available EPackages:<br/>"
+			 + environment.getMetamodels().stream()
+			 			  .map(pkg -> "<li>" + pkg.getName() + " (nsPrefix:" + pkg.getNsPrefix() + ", nsURI: " + pkg.getNsURI() + ")</li>")
+			 			  .collect(joining("", "<ul>", "</ul>"));
 	}
 
 }


### PR DESCRIPTION
Add tooltips to the editor.

## Changes

 - hovering the `open` and `behavior` keywords show tooltips about their meaning
 - hovering the ID after `behavior` shows available EPackages
 - hovering the name of an open class shows the fully qualified name of this class and where it comes from

## Screenshots

_Hover on open class:_

![image](https://user-images.githubusercontent.com/25926433/86484162-e5977680-bd55-11ea-8f20-c895fa0c0694.png)

_Hover on behavior:_

![image](https://user-images.githubusercontent.com/25926433/86484208-019b1800-bd56-11ea-803b-349f09f730af.png)
