### PR TITLE
[Editor] Show a warning when editing a file not in env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#115](https://github.com/gemoc/ale-lang/pull/115) The interpreter can be run by right-clicking on an ALE project
 - [#129](https://github.com/gemoc/ale-lang/pull/129) The editor warns when the `+=` and `-=` operators ared used on the `result` variable in a void method
 - [#131](https://github.com/gemoc/ale-lang/pull/131) The editor autocompletes attributes and methods of local variables and method parameters (support limited to model instances)
+- [#153](https://github.com/gemoc/ale-lang/pull/153) The editor shows a warning when editing an _.ale_ source file that is not part of the project's ALE environment. A quick fix allows to automatically add the _.ale_ source file to the project's ALE environment
 - [#169](https://github.com/gemoc/ale-lang/pull/169) The editor shows documentation about the _open_ and _behavior_ keywords on hover
 - [#169](https://github.com/gemoc/ale-lang/pull/169) The editor shows the fully qualified name of an open class on hover as well as information about its EPackage
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/plugin.xml
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/plugin.xml
@@ -14,6 +14,15 @@
       <super type="org.eclipse.core.resources.problemmarker" />
       <super type="org.eclipse.core.resources.textmarker" /> 
       <persistent value="true" />
+      <super
+            type="org.eclipse.emf.ecoretools.ale.xtext.ui.ale.check.normal">
+      </super>
    </extension>
-      
+	
+   <extension point="org.eclipse.core.resources.markers"
+         id="SourceFileNotInEnvironmentMarker"
+         name="ALE Problem">
+      <persistent value="true" />
+      <super type="org.eclipse.emf.ecoretools.ale.xtext.AleMarker" />
+   </extension>
 </plugin>

--- a/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleMarkerTypes.xtend
+++ b/plugins/org.eclipse.emf.ecoretools.ale.xtext/src/org/eclipse/emf/ecoretools/validation/AleMarkerTypes.xtend
@@ -1,0 +1,19 @@
+package org.eclipse.emf.ecoretools.validation
+
+/**
+ * IDs of ALE markers.
+ */
+class AleMarkerTypes {
+	
+	/**
+	 * Default marker ID.
+	 */
+	public static val String DEFAULT = "org.eclipse.emf.ecoretools.ale.xtext.AleMarker"
+	
+	/**
+	 * Marker indicating that the source file is not in the project's ALE environment.
+	 */
+	public static val String SOURCE_FILE_NOT_IN_ENV = "org.eclipse.emf.ecoretools.ale.xtext.SourceFileNotInEnvironmentMarker"
+	
+	
+}


### PR DESCRIPTION
Closes #153

The warning is accompagnied by a quick fix that adds the file to the enclosing project's environment (which can be stored in preferences or in a .dsl file).

## Demo

<div align="center">

_Editing a file that is not in the .dsl/preferences_:

![demo-issue-153](https://user-images.githubusercontent.com/25926433/86514843-1ee2eb80-be15-11ea-9b98-3919e2d0d228.gif)

</div>