### PR TITLE
Fix project creation on linux

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/env/impl/FileBasedAleEnvironment.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/env/impl/FileBasedAleEnvironment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and Obeo.
+ * Copyright (c) 2017, 2020 Inria and Obeo.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,14 +16,14 @@ import static java.util.stream.Collectors.toList;
 import static org.eclipse.emf.ecoretools.ale.core.io.IOResources.toFile;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 
@@ -145,9 +145,12 @@ public final class FileBasedAleEnvironment extends AbstractAleEnvironment {
 			write(workspaceFile, newProperties);
 		}
 		else if (platformFile != null) {
-			try (FileOutputStream output = new FileOutputStream(platformFile)) {
-				newProperties.store(output, "");
+			StringBuilder sb = new  StringBuilder();
+			sb.append("#\n");
+			for(Entry<Object, Object> entry : newProperties.entrySet()) {
+				sb.append(entry.getKey() + " = " +entry.getValue()+"\n");
 			}
+			Files.write(platformFile.toPath(), sb.toString().getBytes());
 		}
 	}
 	
@@ -186,10 +189,13 @@ public final class FileBasedAleEnvironment extends AbstractAleEnvironment {
 	 * @throws IOException if the properties cannot be saved
 	 */
 	private static void write(IFile workspaceFile, Properties newProperties) throws IOException {
-		ByteArrayOutputStream writableProperties = new ByteArrayOutputStream(100);
-		newProperties.store(writableProperties, "");
+		StringBuilder sb = new  StringBuilder();
+		sb.append("#\n");
+		for(Entry<Object, Object> entry : newProperties.entrySet()) {
+			sb.append(entry.getKey() + " = " +entry.getValue()+"\n");
+		}
 		
-		InputStream readableProperties = new ByteArrayInputStream(writableProperties.toByteArray());
+		InputStream readableProperties = new ByteArrayInputStream(sb.toString().getBytes());
 		try {
 			if (! workspaceFile.exists()) {
 				workspaceFile.create(readableProperties, false, new NullProgressMonitor());

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/IOUtils.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/parser/IOUtils.java
@@ -25,7 +25,7 @@ import org.eclipse.emf.common.util.URI;
 import org.osgi.framework.Bundle;
 
 // TODO [Refactor] Can this be merged with IOResources?
-class IOUtils {
+public class IOUtils {
 	
 	private IOUtils() {
 		// utility classes should not be instantiated
@@ -52,8 +52,8 @@ class IOUtils {
 	/**
 	 * Convert platform URI to file path
 	 */
-	private static String convertToFile(String path) {
-		URI uri = URI.createURI(path);
+	public static String convertToFile(String platformUriString) {
+		URI uri = URI.createURI(platformUriString);
 		
 		String res = null;
 		
@@ -68,7 +68,7 @@ class IOUtils {
 		}
 		
 		if(res == null) {
-			res = path;
+			res = platformUriString;
 		}
 		
 		return res;

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/project/WorkspaceAleProject.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/project/WorkspaceAleProject.java
@@ -183,7 +183,7 @@ public class WorkspaceAleProject {
 			
 			IFile ecoreFile = project.getFolder("model").getFile(project.getName() + ".ecore");
 			ResourceSet resources = new ResourceSetImpl();
-			Resource resource = resources.createResource(URI.createFileURI(ecoreFile.getFullPath().toOSString()));
+			Resource resource = resources.createResource(URI.createPlatformResourceURI(ecoreFile.getFullPath().toOSString(), true));
 			
 			resource.getContents().add(pkg);
 			resource.save(emptyMap());
@@ -205,9 +205,15 @@ public class WorkspaceAleProject {
 			return src.getFullPath();
 		}
 		
+
+		/**
+		 * 
+		 * @param path the path in the wizard as a workspace relative path
+		 * @return the ePackage of the corresponding 
+		 */
 		private static EPackage getEcoreModel(IPath path) {
 			ResourceSet resources = new ResourceSetImpl();
-			Resource resource = resources.getResource(URI.createFileURI(path.toOSString()), true);
+			Resource resource = resources.getResource(URI.createPlatformResourceURI(path.toOSString(), true), true);
 			return (EPackage) resource.getContents().get(0);
 		}
 		

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/project/WorkspaceAleProject.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/src/org/eclipse/emf/ecoretools/ale/ide/ui/project/WorkspaceAleProject.java
@@ -121,7 +121,11 @@ public class WorkspaceAleProject {
 					EPackage epackage = getOrCreateEcoreModel(project, subMonitor.split(1));
 					IPath aleFilePath = createAleSourceFile(project, epackage, subMonitor.split(1));
 					
-					configureAleEnvironment(project, asList(URI.createPlatformResourceURI(epackage.eResource().getURI().toString(), true).toString()), asList(URI.createPlatformResourceURI(aleFilePath.toPortableString(), true).toString()), subMonitor.split(1));
+					
+					configureAleEnvironment(project, 
+							asList(epackage.eResource().getURI().toString()), 
+							asList(URI.createPlatformResourceURI(aleFilePath.toPortableString(), true).toString()), 
+							subMonitor.split(1));
 					createRepresentation(project, epackage, subMonitor.split(1));
 					addJavaNature(project, subMonitor.split(1));
 					

--- a/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/env/WithAbsoluteBehaviorPathsAleEnvironment.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide/src/org/eclipse/emf/ecoretools/ale/ide/env/WithAbsoluteBehaviorPathsAleEnvironment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and Obeo.
+ * Copyright (c) 2017, 2020 Inria and Obeo.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,21 +12,14 @@ package org.eclipse.emf.ecoretools.ale.ide.env;
 
 import static java.util.stream.Collectors.toList;
 
-import java.io.IOException;
-import java.net.URL;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecoretools.ale.core.env.IAleEnvironment;
 import org.eclipse.emf.ecoretools.ale.core.env.impl.AbstractAleEnvironment;
-import org.osgi.framework.Bundle;
+import org.eclipse.emf.ecoretools.ale.core.parser.IOUtils;
 
 /**
  * Decorates an {@link IAleEnvironment ALE environment} and normalizes its URIs
@@ -64,68 +57,10 @@ public class WithAbsoluteBehaviorPathsAleEnvironment extends AbstractAleEnvironm
 	
 	private static Collection<String> resolveUris(Collection<String> uris) {
 		return uris.stream()
-				   .map(uri -> URI.createFileURI(convertToFile(uri)).toFileString())
+				   .map(uri -> URI.createFileURI(IOUtils.convertToFile(uri)).toFileString())
 				   .filter(Objects::nonNull)
 				   .collect(toList());
 	}
 	
-	/**
-	 * Convert platform URI to file path
-	 */
-	public static String convertToFile(String path) {
-		URI uri = URI.createURI(path);
-		
-		String res = null;
-		
-		if(uri.isPlatformResource()) {
-			res = resourceToFile(uri);
-			if(res == null) {
-				res = pluginToFile(resourceToPlugin(uri));
-			}
-		}
-		else if(uri.isPlatformPlugin()) {
-			res = pluginToFile(uri);
-		}
-		
-		if(res == null) {
-			res = path;
-		}
-		
-		return res;
-	}
 	
-	private static String resourceToFile(URI uri) {
-		IWorkspace ws = ResourcesPlugin.getWorkspace();
-		if(ws != null) {
-			IResource file = ws.getRoot().findMember(uri.toPlatformString(true));
-			if(file != null) {
-				return file.getLocationURI().getRawPath();
-			}
-		}
-		return null;
-	}
-	
-	private static String pluginToFile(URI uri) {
-		String pluginName = uri.segment(1);
-		String path = uri.toPlatformString(true).substring(pluginName.length()+1);
-		
-		Bundle plugin = Platform.getBundle(pluginName);
-		URL pluginURL = plugin.getEntry("/");
-		
-		try {
-			String pluginFilePath = FileLocator.toFileURL(pluginURL).getFile();
-			return  pluginFilePath + path.substring(1);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		
-		return null;
-	}
-	
-	/**
-	 * Convert platform:/resource/ to platform:/plugin/
-	 */
-	private static URI resourceToPlugin(URI uri) {
-		return URI.createPlatformPluginURI(uri.toPlatformString(true), true);
-	}
 }


### PR DESCRIPTION
Closes https://github.com/gemoc/ale-lang/issues/158 and https://github.com/gemoc/ale-lang/issues/188

- make sure to use system path (instead of workspace relative path) when creating `file:/` uri
- fix uri saved in the .dsl file when creating project (the uri was of the form : `platform:/resource/platform:/resource/project...`)
- avoid the `/:` in the value parts of the .dsl file

## Changes

This PR also removes some duplicated code between IOUtils and WithAbsoluteBehaviorPathsAleEnvironment
 
 