### PR TITLE
fix path to AleInvocationDelegateFactory in plugin.xml

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/plugin.xml
+++ b/plugins/org.eclipse.emf.ecoretools.ale.ide.ui/plugin.xml
@@ -25,7 +25,7 @@
   </extension>
   <extension point="org.eclipse.emf.ecore.invocation_delegate">
       <factory
-            class="org.eclipse.emf.ecoretools.ale.core.delegate.ALEInvocationDelegateFactory"
+            class="org.eclipse.emf.ecoretools.ale.core.metamodelembedding.AleInvocationDelegateFactory"
             uri="http://implementation/">
       </factory>
    </extension>


### PR DESCRIPTION
AleInvocationDelegateFactory was moved/renamed in
https://github.com/gemoc/ale-lang/pull/136 this PR adapt the plugin.xml to it

(note, Actually I don't really know what is its purpose, I only fixed it to point to an existing file)


