### PR TITLE
Enhance error reporting and detection of assignment on uninitialized variable or feature

### DIFF
--- a/plugins/org.eclipse.emf.ecoretools.ale.core/model/diagnostics.ecore
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/model/diagnostics.ecore
@@ -162,4 +162,7 @@
   <eClassifiers xsi:type="ecore:EDataType" name="ValidationMessageLevel" instanceClassName="org.eclipse.acceleo.query.runtime.ValidationMessageLevel"/>
   <eClassifiers xsi:type="ecore:EClass" name="IllegalAdditionAssignment" eSuperTypes="#//TypeMismatch"/>
   <eClassifiers xsi:type="ecore:EClass" name="IllegalSubstractionAssignment" eSuperTypes="#//TypeMismatch"/>
+  <eClassifiers xsi:type="ecore:EClass" name="Uninitialized" eSuperTypes="#//Message">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/model/diagnostics.genmodel
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/model/diagnostics.genmodel
@@ -153,5 +153,8 @@
     </genClasses>
     <genClasses ecoreClass="diagnostics.ecore#//IllegalAdditionAssignment"/>
     <genClasses ecoreClass="diagnostics.ecore#//IllegalSubstractionAssignment"/>
+    <genClasses ecoreClass="diagnostics.ecore#//Uninitialized">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagnostics.ecore#//Uninitialized/name"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/DiagnosticsFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/DiagnosticsFactory.java
@@ -373,6 +373,15 @@ public interface DiagnosticsFactory extends EFactory {
 	IllegalSubstractionAssignment createIllegalSubstractionAssignment();
 
 	/**
+	 * Returns a new object of class '<em>Uninitialized</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Uninitialized</em>'.
+	 * @generated
+	 */
+	Uninitialized createUninitialized();
+
+	/**
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/DiagnosticsPackage.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/DiagnosticsPackage.java
@@ -3842,6 +3842,97 @@ public interface DiagnosticsPackage extends EPackage {
 	int ILLEGAL_SUBSTRACTION_ASSIGNMENT_OPERATION_COUNT = TYPE_MISMATCH_OPERATION_COUNT + 0;
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.UninitializedImpl <em>Uninitialized</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.UninitializedImpl
+	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.DiagnosticsPackageImpl#getUninitialized()
+	 * @generated
+	 */
+	int UNINITIALIZED = 39;
+
+	/**
+	 * The feature id for the '<em><b>Location</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED__LOCATION = MESSAGE__LOCATION;
+
+	/**
+	 * The feature id for the '<em><b>Stacktrace</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED__STACKTRACE = MESSAGE__STACKTRACE;
+
+	/**
+	 * The feature id for the '<em><b>Context</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED__CONTEXT = MESSAGE__CONTEXT;
+
+	/**
+	 * The feature id for the '<em><b>Whole Code</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED__WHOLE_CODE = MESSAGE__WHOLE_CODE;
+
+	/**
+	 * The feature id for the '<em><b>Incriminated Code</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED__INCRIMINATED_CODE = MESSAGE__INCRIMINATED_CODE;
+
+	/**
+	 * The feature id for the '<em><b>Source</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED__SOURCE = MESSAGE__SOURCE;
+
+	/**
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED__NAME = MESSAGE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Uninitialized</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED_FEATURE_COUNT = MESSAGE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Uninitialized</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int UNINITIALIZED_OPERATION_COUNT = MESSAGE_OPERATION_COUNT + 0;
+
+	/**
 	 * The meta object id for the '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Operator <em>Operator</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -3849,7 +3940,7 @@ public interface DiagnosticsPackage extends EPackage {
 	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.DiagnosticsPackageImpl#getOperator()
 	 * @generated
 	 */
-	int OPERATOR = 39;
+	int OPERATOR = 40;
 
 	/**
 	 * The meta object id for the '<em>IType</em>' data type.
@@ -3859,7 +3950,7 @@ public interface DiagnosticsPackage extends EPackage {
 	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.DiagnosticsPackageImpl#getIType()
 	 * @generated
 	 */
-	int ITYPE = 40;
+	int ITYPE = 41;
 
 	/**
 	 * The meta object id for the '<em>Throwable</em>' data type.
@@ -3869,7 +3960,7 @@ public interface DiagnosticsPackage extends EPackage {
 	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.DiagnosticsPackageImpl#getThrowable()
 	 * @generated
 	 */
-	int THROWABLE = 41;
+	int THROWABLE = 42;
 
 	/**
 	 * The meta object id for the '<em>Validation Message Level</em>' data type.
@@ -3879,7 +3970,7 @@ public interface DiagnosticsPackage extends EPackage {
 	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.DiagnosticsPackageImpl#getValidationMessageLevel()
 	 * @generated
 	 */
-	int VALIDATION_MESSAGE_LEVEL = 42;
+	int VALIDATION_MESSAGE_LEVEL = 43;
 
 
 	/**
@@ -4944,6 +5035,27 @@ public interface DiagnosticsPackage extends EPackage {
 	EClass getIllegalSubstractionAssignment();
 
 	/**
+	 * Returns the meta object for class '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized <em>Uninitialized</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Uninitialized</em>'.
+	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized
+	 * @generated
+	 */
+	EClass getUninitialized();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized#getName <em>Name</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized#getName()
+	 * @see #getUninitialized()
+	 * @generated
+	 */
+	EAttribute getUninitialized_Name();
+
+	/**
 	 * Returns the meta object for enum '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Operator <em>Operator</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -5886,6 +5998,24 @@ public interface DiagnosticsPackage extends EPackage {
 		 * @generated
 		 */
 		EClass ILLEGAL_SUBSTRACTION_ASSIGNMENT = eINSTANCE.getIllegalSubstractionAssignment();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.UninitializedImpl <em>Uninitialized</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.UninitializedImpl
+		 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.DiagnosticsPackageImpl#getUninitialized()
+		 * @generated
+		 */
+		EClass UNINITIALIZED = eINSTANCE.getUninitialized();
+
+		/**
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute UNINITIALIZED__NAME = eINSTANCE.getUninitialized_Name();
 
 		/**
 		 * The meta object literal for the '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Operator <em>Operator</em>}' enum.

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/Uninitialized.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/Uninitialized.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *    Inria - initial API and implementation
+ */
+package org.eclipse.emf.ecoretools.ale.core.diagnostics;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Uninitialized</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized#getName <em>Name</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.DiagnosticsPackage#getUninitialized()
+ * @model
+ * @generated
+ */
+public interface Uninitialized extends Message {
+	/**
+	 * Returns the value of the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see #setName(String)
+	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.DiagnosticsPackage#getUninitialized_Name()
+	 * @model
+	 * @generated
+	 */
+	String getName();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized#getName <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Name</em>' attribute.
+	 * @see #getName()
+	 * @generated
+	 */
+	void setName(String value);
+
+} // Uninitialized

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/DiagnosticsFactoryImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/DiagnosticsFactoryImpl.java
@@ -53,6 +53,7 @@ import org.eclipse.emf.ecoretools.ale.core.diagnostics.ReservedKeywordSelf;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeHasNamesakes;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeMismatch;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeNotFound;
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.UnsupportedOperator;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableAlreadyDefined;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableNotFound;
@@ -140,6 +141,7 @@ public class DiagnosticsFactoryImpl extends EFactoryImpl implements DiagnosticsF
 			case DiagnosticsPackage.ACCELEO_VALIDATION_MESSAGE: return createAcceleoValidationMessage();
 			case DiagnosticsPackage.ILLEGAL_ADDITION_ASSIGNMENT: return createIllegalAdditionAssignment();
 			case DiagnosticsPackage.ILLEGAL_SUBSTRACTION_ASSIGNMENT: return createIllegalSubstractionAssignment();
+			case DiagnosticsPackage.UNINITIALIZED: return createUninitialized();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -614,6 +616,17 @@ public class DiagnosticsFactoryImpl extends EFactoryImpl implements DiagnosticsF
 	public IllegalSubstractionAssignment createIllegalSubstractionAssignment() {
 		IllegalSubstractionAssignmentImpl illegalSubstractionAssignment = new IllegalSubstractionAssignmentImpl();
 		return illegalSubstractionAssignment;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Uninitialized createUninitialized() {
+		UninitializedImpl uninitialized = new UninitializedImpl();
+		return uninitialized;
 	}
 
 	/**

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/DiagnosticsPackageImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/DiagnosticsPackageImpl.java
@@ -58,6 +58,7 @@ import org.eclipse.emf.ecoretools.ale.core.diagnostics.ReservedKeywordSelf;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeHasNamesakes;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeMismatch;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeNotFound;
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.UnsupportedOperator;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableAlreadyDefined;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableNotFound;
@@ -343,6 +344,13 @@ public class DiagnosticsPackageImpl extends EPackageImpl implements DiagnosticsP
 	 * @generated
 	 */
 	private EClass illegalSubstractionAssignmentEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass uninitializedEClass = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -1445,6 +1453,26 @@ public class DiagnosticsPackageImpl extends EPackageImpl implements DiagnosticsP
 	 * @generated
 	 */
 	@Override
+	public EClass getUninitialized() {
+		return uninitializedEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EAttribute getUninitialized_Name() {
+		return (EAttribute)uninitializedEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public EEnum getOperator() {
 		return operatorEEnum;
 	}
@@ -1647,6 +1675,9 @@ public class DiagnosticsPackageImpl extends EPackageImpl implements DiagnosticsP
 
 		illegalSubstractionAssignmentEClass = createEClass(ILLEGAL_SUBSTRACTION_ASSIGNMENT);
 
+		uninitializedEClass = createEClass(UNINITIALIZED);
+		createEAttribute(uninitializedEClass, UNINITIALIZED__NAME);
+
 		// Create enums
 		operatorEEnum = createEEnum(OPERATOR);
 
@@ -1725,6 +1756,7 @@ public class DiagnosticsPackageImpl extends EPackageImpl implements DiagnosticsP
 		acceleoValidationMessageEClass.getESuperTypes().add(this.getMessage());
 		illegalAdditionAssignmentEClass.getESuperTypes().add(this.getTypeMismatch());
 		illegalSubstractionAssignmentEClass.getESuperTypes().add(this.getTypeMismatch());
+		uninitializedEClass.getESuperTypes().add(this.getMessage());
 
 		// Initialize classes, features, and operations; add parameters
 		initEClass(attributeNotFoundEClass, AttributeNotFound.class, "AttributeNotFound", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -1865,6 +1897,9 @@ public class DiagnosticsPackageImpl extends EPackageImpl implements DiagnosticsP
 		initEClass(illegalAdditionAssignmentEClass, IllegalAdditionAssignment.class, "IllegalAdditionAssignment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(illegalSubstractionAssignmentEClass, IllegalSubstractionAssignment.class, "IllegalSubstractionAssignment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+
+		initEClass(uninitializedEClass, Uninitialized.class, "Uninitialized", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getUninitialized_Name(), theEcorePackage.getEString(), "name", null, 0, 1, Uninitialized.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		// Initialize enums and add enum literals
 		initEEnum(operatorEEnum, Operator.class, "Operator");

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/UninitializedImpl.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/UninitializedImpl.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2020 Inria and Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *    Inria - initial API and implementation
+ */
+package org.eclipse.emf.ecoretools.ale.core.diagnostics.impl;
+
+import org.eclipse.emf.common.notify.Notification;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.DiagnosticsPackage;
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>Uninitialized</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.UninitializedImpl#getName <em>Name</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class UninitializedImpl extends MessageImpl implements Uninitialized {
+	/**
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String NAME_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
+	protected String name = NAME_EDEFAULT;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected UninitializedImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return DiagnosticsPackage.Literals.UNINITIALIZED;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setName(String newName) {
+		String oldName = name;
+		name = newName;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, DiagnosticsPackage.UNINITIALIZED__NAME, oldName, name));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case DiagnosticsPackage.UNINITIALIZED__NAME:
+				return getName();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case DiagnosticsPackage.UNINITIALIZED__NAME:
+				setName((String)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case DiagnosticsPackage.UNINITIALIZED__NAME:
+				setName(NAME_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case DiagnosticsPackage.UNINITIALIZED__NAME:
+				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (name: ");
+		result.append(name);
+		result.append(')');
+		return result.toString();
+	}
+
+} //UninitializedImpl

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/util/DiagnosticsAdapterFactory.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/util/DiagnosticsAdapterFactory.java
@@ -45,6 +45,7 @@ import org.eclipse.emf.ecoretools.ale.core.diagnostics.ReservedKeywordSelf;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeHasNamesakes;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeMismatch;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeNotFound;
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.UnsupportedOperator;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableAlreadyDefined;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableNotFound;
@@ -260,6 +261,10 @@ public class DiagnosticsAdapterFactory extends AdapterFactoryImpl {
 			@Override
 			public Adapter caseIllegalSubstractionAssignment(IllegalSubstractionAssignment object) {
 				return createIllegalSubstractionAssignmentAdapter();
+			}
+			@Override
+			public Adapter caseUninitialized(Uninitialized object) {
+				return createUninitializedAdapter();
 			}
 			@Override
 			public Adapter defaultCase(EObject object) {
@@ -824,6 +829,20 @@ public class DiagnosticsAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createIllegalSubstractionAssignmentAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized <em>Uninitialized</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized
+	 * @generated
+	 */
+	public Adapter createUninitializedAdapter() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/util/DiagnosticsSwitch.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src-gen/org/eclipse/emf/ecoretools/ale/core/diagnostics/util/DiagnosticsSwitch.java
@@ -43,6 +43,7 @@ import org.eclipse.emf.ecoretools.ale.core.diagnostics.ReservedKeywordSelf;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeHasNamesakes;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeMismatch;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeNotFound;
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.UnsupportedOperator;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableAlreadyDefined;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableNotFound;
@@ -379,6 +380,13 @@ public class DiagnosticsSwitch<T> extends Switch<T> {
 				T result = caseIllegalSubstractionAssignment(illegalSubstractionAssignment);
 				if (result == null) result = caseTypeMismatch(illegalSubstractionAssignment);
 				if (result == null) result = caseMessage(illegalSubstractionAssignment);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case DiagnosticsPackage.UNINITIALIZED: {
+				Uninitialized uninitialized = (Uninitialized)theEObject;
+				T result = caseUninitialized(uninitialized);
+				if (result == null) result = caseMessage(uninitialized);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -968,6 +976,21 @@ public class DiagnosticsSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseIllegalSubstractionAssignment(IllegalSubstractionAssignment object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Uninitialized</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Uninitialized</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseUninitialized(Uninitialized object) {
 		return null;
 	}
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/ConsoleDiagnosticsFormatter.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/diagnostics/impl/ConsoleDiagnosticsFormatter.java
@@ -33,6 +33,7 @@ import org.eclipse.emf.ecoretools.ale.core.diagnostics.Operator;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.ProhibitedAssignmentToSelf;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeMismatch;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.TypeNotFound;
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.Uninitialized;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.UnsupportedOperator;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableAlreadyDefined;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.VariableNotFound;
@@ -154,6 +155,14 @@ public class ConsoleDiagnosticsFormatter extends DiagnosticsSwitch<String> imple
 		String underline = underlineFirst(snippet, error.getIncriminatedCode());
 		String advises   = replacementProposals(error.getName(), getScope(error).getVariableNames());
 		return headline + nlnl() + snippet + nl() + underline + nl() + advises;
+	}
+	
+	@Override
+	public String caseUninitialized(Uninitialized error) {
+		String headline  = Messages.uninitializedVariableOrFeature(error.getName());
+		String snippet   = Messages.codeSnippet(error.getLocation().getLine(), error.getWholeCode());
+		String underline = underlineFirst(snippet, error.getIncriminatedCode());
+		return headline + nlnl() + snippet + nl() + underline + nl() ;
 	}
 
 	private static String doPropositions(String actual, Collection<String> expected) {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/Messages.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/Messages.java
@@ -44,6 +44,7 @@ public final class Messages extends NLS {
     public static String IF_GUARD_IS_NOT_BOOLEAN;
     public static String ATTRIBUTE_NOT_FOUND;
     public static String VARIABLE_NOT_FOUND;
+    public static String UNINITIALIZED;
     public static String METHOD_NOT_FOUND;
     public static String TYPE_MISMATCH;
     public static String CODE_SNIPPET;
@@ -125,6 +126,10 @@ public final class Messages extends NLS {
     
     public static String variableNotFound(String name) {
     	return MessageFormat.format(VARIABLE_NOT_FOUND, name);
+    }
+    
+    public static String uninitializedVariableOrFeature(String varName) {
+    	return MessageFormat.format(UNINITIALIZED, varName);
     }
     
     public static String typeMismatch(Collection<IType> expectedTypes, Collection<IType> actualTypes) {

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/MethodEvaluator.java
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/MethodEvaluator.java
@@ -46,6 +46,7 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecoretools.ale.core.Activator;
+import org.eclipse.emf.ecoretools.ale.core.diagnostics.InternalError;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.Operator;
 import org.eclipse.emf.ecoretools.ale.core.diagnostics.impl.ConsoleDiagnosticsFormatter;
 import org.eclipse.emf.ecoretools.ale.core.env.IAleEnvironment;
@@ -287,6 +288,11 @@ public class MethodEvaluator {
 		
 		Object rawOwner = aqlEval(featAssign.getTarget());
 		if (! (rawOwner instanceof EObject)) {
+			if(rawOwner == null && featAssign.getTarget() != null) {
+				diagnostic.add(errors.uninitializedFeature(featAssign.getTarget().toString(), featAssign.getTarget(),  scopes));
+			} else {
+				diagnostic.add(errors.internalError(rawOwner, new Throwable("Unsupported feature assignment "), featAssign , scopes));	
+			}
 			stopExecution(ROOT_ERROR_MESSAGE);
 		}
 		validateAndStoreType(featAssign.getTarget());

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/messages.properties
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/messages.properties
@@ -23,6 +23,7 @@ UNSUPPORTED_REMOVAL = ''{0}'' does not support the `-=` operator.\r\n\r\n{1}
 VARIABLE_ALREADY_BOUND = A variable named `{0}` already exists.
 VARIABLE_NOT_FOUND = Cannot find variable `{0}`.
 ATTRIBUTE_NOT_FOUND = Cannot find attribute `{0}` in class `{1}`.
+UNINITIALIZED = Variable or feature `{0}` not initialized.
 METHOD_NOT_FOUND = Cannot find method `{0}` in caller''s class `{1}`.
 PROPOSITIONS = Maybe you want one of the following?{0}
 

--- a/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/messages.properties
+++ b/plugins/org.eclipse.emf.ecoretools.ale.core/src/org/eclipse/emf/ecoretools/ale/core/interpreter/internal/messages.properties
@@ -23,7 +23,7 @@ UNSUPPORTED_REMOVAL = ''{0}'' does not support the `-=` operator.\r\n\r\n{1}
 VARIABLE_ALREADY_BOUND = A variable named `{0}` already exists.
 VARIABLE_NOT_FOUND = Cannot find variable `{0}`.
 ATTRIBUTE_NOT_FOUND = Cannot find attribute `{0}` in class `{1}`.
-UNINITIALIZED = Variable or feature `{0}` not initialized.
+UNINITIALIZED = Variable or feature not initialized.
 METHOD_NOT_FOUND = Cannot find method `{0}` in caller''s class `{1}`.
 PROPOSITIONS = Maybe you want one of the following?{0}
 

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/diagnostics/assignmentToUninitializedFeature.ale
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/diagnostics/assignmentToUninitializedFeature.ale
@@ -1,0 +1,14 @@
+behavior test.calldynaattr;
+open class ClassA {
+	
+	
+	ClassA aClassA;	
+	String msg;
+	
+	@main
+	def String main() {
+		self.aClassA.msg := '';  // should fail and report an exception because aClassA isn't initialized
+		
+		result := 'res';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/diagnostics/assignmentToUninitializedVariable.ale
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/diagnostics/assignmentToUninitializedVariable.ale
@@ -1,0 +1,14 @@
+behavior test.calldynaattr;
+open class ClassA {
+	
+	
+	String msg;
+	
+	@main
+	def String main() {
+		ClassA aClassA;	
+		aClassA.msg := '';  // should fail and report an exception because aClassA isn't initialized
+		
+		result := 'res';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/eval/uninitializedClassAttributeAssignment.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/eval/uninitializedClassAttributeAssignment.implem
@@ -1,0 +1,14 @@
+behavior test.calldynaattr;
+open class ClassA {
+	
+	ClassA aClassA;
+	String msg;
+	
+	@main
+	def String main() {
+		
+		self.aClassA.msg := '';  // should fail and report an exception because aClassA isn't initialized
+		
+		result := 'res';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/eval/uninitializedVariableAssignment.implem
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/input/eval/uninitializedVariableAssignment.implem
@@ -1,0 +1,14 @@
+behavior test.calldynaattr;
+open class ClassA {
+	
+	
+	String msg;
+	
+	@main
+	def String main() {
+		ClassA aClassA;	
+		aClassA.msg := '';  // should fail and report an exception because aClassA isn't initialized
+		
+		result := 'res';
+	}
+}

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/EvalTest.java
@@ -191,6 +191,38 @@ public class EvalTest {
 		assertEquals(Diagnostic.ERROR, res.getDiagnostic().getSeverity());
 		assertEquals(null, res.getValue());
 	}
+	
+	/**
+	 * test contributing to https://github.com/gemoc/ale-lang/issues/38
+	 */
+	@Test
+	public void testUninitializedClassAttributeAssignment()  throws ClosedAleEnvironmentException {
+		environment = IAleEnvironment.fromPaths(asList("model/test.ecore"),
+				asList("input/eval/uninitializedClassAttributeAssignment.implem"));
+		IBehaviors behaviors = environment.getBehaviors();
+		EObject caller = environment.loadModel(URI.createURI("model/ClassA.xmi")).get(0);
+		Method main = behaviors.getMainMethods().get(0);
+		IEvaluationResult res = environment.getInterpreter().eval(caller, main, asList());
+
+		assertEquals(Diagnostic.ERROR, res.getDiagnostic().getSeverity());
+		assertEquals(null, res.getValue());
+	}
+	
+	/**
+	 * test contributing to https://github.com/gemoc/ale-lang/issues/38
+	 */
+	@Test
+	public void testUninitializedVariableAssignment()  throws ClosedAleEnvironmentException {
+		environment = IAleEnvironment.fromPaths(asList("model/test.ecore"),
+				asList("input/eval/uninitializedVariableAssignment.implem"));
+		IBehaviors behaviors = environment.getBehaviors();
+		EObject caller = environment.loadModel(URI.createURI("model/ClassA.xmi")).get(0);
+		Method main = behaviors.getMainMethods().get(0);
+		IEvaluationResult res = environment.getInterpreter().eval(caller, main, asList());
+
+		assertEquals(Diagnostic.ERROR, res.getDiagnostic().getSeverity());
+		assertEquals(null, res.getValue());
+	}
 
 	@Test
 	public void testAccessSelfAttribute()  throws ClosedAleEnvironmentException {

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/InterpreterDiagnosticTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/InterpreterDiagnosticTest.java
@@ -198,6 +198,40 @@ public class InterpreterDiagnosticTest {
 						  "  At input/diagnostics/assignmentToVariableUndeclared.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
+	
+	@Test
+	public void assignmentToUninitializedVariable() throws ClosedAleEnvironmentException {
+		environment = IAleEnvironment.fromPaths(asList("model/test.ecore"), asList("input/diagnostics/assignmentToUninitializedVariable.ale"));
+		
+		EObject caller = environment.loadModel(URI.createURI("model/ClassA.xmi")).get(0);
+		IBehaviors behaviors = environment.getBehaviors();
+		Method main = behaviors.getMainMethods().get(0);
+		environment.getInterpreter().eval(caller, main, asList());
+		environment.getInterpreter().getLogger().diagnosticForHuman();
+
+		String expected = "Variable or feature not initialized." + nlnl() + 
+						  "10| aClassA" + nl() + 
+						  nlnl() +
+						  "  At input/diagnostics/assignmentToUninitializedVariable.ale:10" + nl(); 
+		assertEquals("Wrong output on stderr", expected, getErr());
+	}
+	
+	@Test
+	public void assignmentToUninitializedFeature() throws ClosedAleEnvironmentException {
+		environment = IAleEnvironment.fromPaths(asList("model/test.ecore"), asList("input/diagnostics/assignmentToUninitializedFeature.ale"));
+		
+		EObject caller = environment.loadModel(URI.createURI("model/ClassA.xmi")).get(0);
+		IBehaviors behaviors = environment.getBehaviors();
+		Method main = behaviors.getMainMethods().get(0);
+		environment.getInterpreter().eval(caller, main, asList());
+		environment.getInterpreter().getLogger().diagnosticForHuman();
+
+		String expected = "Variable or feature not initialized." + nlnl() + 
+						  "10| self.aClassA" + nl() + 
+						  nlnl() +
+						  "  At input/diagnostics/assignmentToUninitializedFeature.ale:10" + nl(); 
+		assertEquals("Wrong output on stderr", expected, getErr());
+	}
 
 	@Test
 	public void declarationOfVariableAlreadyDeclared() throws ClosedAleEnvironmentException {

--- a/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/InterpreterDiagnosticTest.java
+++ b/tests/org.eclipse.emf.ecoretools.ale.core.tests/src/org/eclipse/emf/ecoretools/ale/core/interpreter/test/InterpreterDiagnosticTest.java
@@ -12,21 +12,17 @@ package org.eclipse.emf.ecoretools.ale.core.interpreter.test;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-import java.util.List;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecoretools.ale.core.diagnostics.Message;
 import org.eclipse.emf.ecoretools.ale.core.env.ClosedAleEnvironmentException;
 import org.eclipse.emf.ecoretools.ale.core.env.IAleEnvironment;
 import org.eclipse.emf.ecoretools.ale.core.env.IBehaviors;
-import org.eclipse.emf.ecoretools.ale.core.validation.ALEValidator;
 import org.eclipse.emf.ecoretools.ale.implementation.Method;
 import org.junit.After;
 import org.junit.Before;
@@ -89,7 +85,7 @@ public class InterpreterDiagnosticTest {
 
 		String expected = "Type mismatch between expected type `ecore::EString` and actual type `java.lang.Integer`." + nlnl() + 
 						  "9| self.str := 42;" + nl() + 
-						  "               ^^ should be `ecore::EString`" + nlnl() + 
+						  "               ^^ should be `ecore::EString`" + nl() + 
 						  "  At input/diagnostics/assignmentToDynamicFeatureTypeMismatch.ale:9" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -106,7 +102,7 @@ public class InterpreterDiagnosticTest {
 
 		String expected = "Cannot find attribute `str` in class `ClassA`." + nlnl() + 
 						  "7| self.str := self;" + nl() + 
-						  "        ^^^" + nlnl() + 
+						  "        ^^^" + nl() + 
 						  "  At input/diagnostics/assignmentToDynamicFeatureUndeclared.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -125,7 +121,7 @@ public class InterpreterDiagnosticTest {
 						  "7| result := 'Hello World!';" + nl() +
 						  "   ^^^^^^" + nl() +
 						  "`result` is not available in a void method. Maybe you want one of the following?" + nlnl() + 
-						  "    self" + nlnl() +
+						  "    self" + nl() +
 						  "  At input/diagnostics/assignmentToResultInVoidMethod.ale:7" + nl();
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -144,7 +140,7 @@ public class InterpreterDiagnosticTest {
 						  "10| def boolean foo(String name, int age) {" + nl() + 
 						  "11| 		// result := true;" + nl() + 
 						  "12| 	}" + nl() + 
-						  "        ^ missing `result := ...;` " + nlnl() +
+						  "        ^ missing `result := ...;` " + nl() +
 						  "  At input/diagnostics/assignmentToResultMissingInNonVoidMethod.ale:10" + nl() +
 						  "  At input/diagnostics/assignmentToResultMissingInNonVoidMethod.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
@@ -162,7 +158,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "`self` cannot be assigned." + nlnl() + 
 						  "7| self := 42;" + nl() + 
-						  "   ^^^^ reserved keyword" + nlnl() + 
+						  "   ^^^^ reserved keyword" + nl() + 
 						  "  At input/diagnostics/assignmentToSelf.ale:7" + nl();
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -179,7 +175,7 @@ public class InterpreterDiagnosticTest {
 
 		String expected = "Type mismatch between expected type `ecore::EString` and actual type `java.lang.Integer`." + nlnl() + 
 						  "8| str := 42;" + nl() + 
-						  "          ^^ should be `ecore::EString`" + nlnl() + 
+						  "          ^^ should be `ecore::EString`" + nl() + 
 						  "  At input/diagnostics/assignmentToVariableTypeMismatch.ale:8" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -198,7 +194,7 @@ public class InterpreterDiagnosticTest {
 						  "7| str := self;" + nl() + 
 						  "   ^^^" + nl() + 
 						  "Maybe you want one of the following?" + nlnl() + 
-						  "    self" + nlnl() + 
+						  "    self" + nl() + 
 						  "  At input/diagnostics/assignmentToVariableUndeclared.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -215,7 +211,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "A variable named `sentences` already exists." + nlnl() + 
 						  "8| Sequence(String) sentences := Sequence{'Hello World!'};" + nl() + 
-						  "                    ^^^^^^^^^ already declared at :7" + nlnl() +
+						  "                    ^^^^^^^^^ already declared at :7" + nl() +
 						  "  At input/diagnostics/declarationOfVariableAlreadyDeclared.ale:8" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -232,7 +228,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "A variable named `number` already exists." + nlnl() + 
 						  "11| int number := 42;" + nl() + 
-						  "        ^^^^^^ already declared at :10" + nlnl() + 
+						  "        ^^^^^^ already declared at :10" + nl() + 
 						  "  At input/diagnostics/declarationOfVariableNamedAfterParameter.ale:11" + nl() + 
 						  "  At input/diagnostics/declarationOfVariableNamedAfterParameter.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
@@ -250,7 +246,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `ecore::EString` and actual type `Set(java.lang.String)`." + nlnl() + 
 						  "7| String str := OrderedSet{'Hello World!'};" + nl() +
-						  "                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ should be `ecore::EString`" + nlnl() + 
+						  "                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ should be `ecore::EString`" + nl() + 
 						  "  At input/diagnostics/declarationOfVariableWithIllegalInitialValue.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -267,7 +263,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Cannot iterate over `java.lang.Integer`" + nlnl() + 
 						  "7| for (i in 42) {" + nl() + 
-						  "             ^^ should be a Sequence or an OrderedSet" + nlnl() + 
+						  "             ^^ should be a Sequence or an OrderedSet" + nl() + 
 						  "  At input/diagnostics/foreachNotIterable.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -286,7 +282,7 @@ public class InterpreterDiagnosticTest {
 						  "11| for (i in [1..5]) {" + nl() + 
 						  "12| 		" + nl() + 
 						  "13| 		}" + nl() +
-						  "         ^ already declared at :10" + nlnl() + 
+						  "         ^ already declared at :10" + nl() + 
 						  "  At input/diagnostics/foreachVariableAlreadyBoundToParameter.ale:11" + nl() +
 						  "  At input/diagnostics/foreachVariableAlreadyBoundToParameter.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
@@ -306,7 +302,7 @@ public class InterpreterDiagnosticTest {
 						  "8| for (i in [1..5]) {" + nl() + 
 						  "9| 		" + nl() + 
 						  "10| 		}" + nl() + 
-						  "        ^ already declared at :7" + nlnl() + 
+						  "        ^ already declared at :7" + nl() + 
 						  "  At input/diagnostics/foreachVariableAlreadyBoundToVariable.ale:8" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -323,7 +319,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `ecore::EBoolean` and actual type `java.lang.String`." + nlnl() + 
 						  "7| if ('Hello World!') {" + nl() + 
-						  "       ^^^^^^^^^^^^^^ should be `ecore::EBoolean`" + nlnl() + 
+						  "       ^^^^^^^^^^^^^^ should be `ecore::EBoolean`" + nl() + 
 						  "  At input/diagnostics/ifNonBooleanCondition.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -340,7 +336,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "`test::ClassA` does not support the `+=` operator" + nlnl() + 
 						  "8| other += self;" + nl() + 
-						  "   ^^^^^" + nlnl() + 
+						  "   ^^^^^" + nl() + 
 						  "  At input/diagnostics/insertionToVariableThatDoesNotSupportOperator.ale:8" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -357,7 +353,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `Sequence(ecore::EString)` and actual type `Sequence(java.lang.Integer)`." + nlnl() + 
 						  "8| numbers += Sequence{3, 4, 5};" + nl() + 
-						  "              ^^^^^^^^^^^^^^^^^ should be `Sequence(ecore::EString)`" + nlnl() + 
+						  "              ^^^^^^^^^^^^^^^^^ should be `Sequence(ecore::EString)`" + nl() + 
 						  "  At input/diagnostics/insertionToVariableTypeMismatch.ale:8" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -376,7 +372,7 @@ public class InterpreterDiagnosticTest {
 						  "7| str += ' World!';" + nl() + 
 						  "   ^^^" + nl() + 
 						  "Maybe you want one of the following?" + nlnl() + 
-						  "    self" + nlnl() + 
+						  "    self" + nl() + 
 						  "  At input/diagnostics/insertionToVariableUndeclared.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -393,7 +389,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "`ecore::EBoolean` does not support the `+=` operator" + nlnl() + 
 				"9| self.isHappy += true;" + nl() + 
-				"        ^^^^^^^" + nlnl() + 
+				"        ^^^^^^^" + nl() + 
 				"  At input/diagnostics/insertionToDynamicFeatureThatDoesNotSupportOperator.ale:9" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -410,7 +406,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `ecore::EInt` and actual type `java.lang.Boolean`." + nlnl() + 
 				"9| self.i += true;" + nl() + 
-				"             ^^^^ should be `ecore::EInt`" + nlnl() + 
+				"             ^^^^ should be `ecore::EInt`" + nl() + 
 				"  At input/diagnostics/insertionToDynamicFeatureTypeMismatch.ale:9" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -427,7 +423,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Cannot find attribute `undeclared` in class `ClassA`." + nlnl() + 
 				"7| self.undeclared += 42;" + nl() + 
-				"        ^^^^^^^^^^" + nlnl() + 
+				"        ^^^^^^^^^^" + nl() + 
 				"  At input/diagnostics/insertionToDynamicFeatureUndeclared.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -444,7 +440,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "`ecore::EBoolean` does not support the `+=` operator" + nlnl() + 
 				"7| self.bool += true;" + nl() + 
-				"        ^^^^" + nlnl() + 
+				"        ^^^^" + nl() + 
 				"  At input/diagnostics/insertionToStaticFeatureThatDoesNotSupportOperator.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -461,7 +457,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `Sequence(ecore::EString)` and actual type `java.lang.Boolean`." + nlnl() + 
 				"7| self.strings += true;" + nl() + 
-				"                   ^^^^ should be `Sequence(ecore::EString)`" + nlnl() + 
+				"                   ^^^^ should be `Sequence(ecore::EString)`" + nl() + 
 				"  At input/diagnostics/insertionToStaticFeatureTypeMismatch.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -478,7 +474,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "`ecore::EBoolean` does not support the `-=` operator" + nlnl() + 
 				"9| self.isHappy -= true;" + nl() + 
-				"        ^^^^^^^" + nlnl() + 
+				"        ^^^^^^^" + nl() + 
 				"  At input/diagnostics/removeToDynamicFeatureThatDoesNotSupportOperator.ale:9" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -495,7 +491,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `ecore::EInt` and actual type `java.lang.Boolean`." + nlnl() + 
 				"9| self.i -= true;" + nl() + 
-				"             ^^^^ should be `ecore::EInt`" + nlnl() + 
+				"             ^^^^ should be `ecore::EInt`" + nl() + 
 				"  At input/diagnostics/removeToDynamicFeatureTypeMismatch.ale:9" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -512,7 +508,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Cannot find attribute `undeclared` in class `ClassA`." + nlnl() + 
 				"7| self.undeclared -= 42;" + nl() + 
-				"        ^^^^^^^^^^" + nlnl() + 
+				"        ^^^^^^^^^^" + nl() + 
 				"  At input/diagnostics/removeToDynamicFeatureUndeclared.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -529,7 +525,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "`ecore::EBoolean` does not support the `-=` operator" + nlnl() + 
 				"7| self.bool -= true;" + nl() + 
-				"        ^^^^" + nlnl() + 
+				"        ^^^^" + nl() + 
 				"  At input/diagnostics/removeToStaticFeatureThatDoesNotSupportOperator.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -546,7 +542,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `Sequence(ecore::EString)` and actual type `java.lang.Boolean`." + nlnl() + 
 				"7| self.strings -= true;" + nl() + 
-				"                   ^^^^ should be `Sequence(ecore::EString)`" + nlnl() + 
+				"                   ^^^^ should be `Sequence(ecore::EString)`" + nl() + 
 				"  At input/diagnostics/removeToStaticFeatureTypeMismatch.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -563,7 +559,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "`test::ClassA` does not support the `-=` operator" + nlnl() + 
 				"8| other -= self;" + nl() + 
-				"   ^^^^^" + nlnl() + 
+				"   ^^^^^" + nl() + 
 				"  At input/diagnostics/removeToVariableThatDoesNotSupportOperator.ale:8" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -580,7 +576,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `Sequence(ecore::EString)` and actual type `Sequence(java.lang.Integer)`." + nlnl() + 
 				"8| numbers -= Sequence{3, 4, 5};" + nl() + 
-				"              ^^^^^^^^^^^^^^^^^ should be `Sequence(ecore::EString)`" + nlnl() + 
+				"              ^^^^^^^^^^^^^^^^^ should be `Sequence(ecore::EString)`" + nl() + 
 				"  At input/diagnostics/removeToVariableTypeMismatch.ale:8" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -599,7 +595,7 @@ public class InterpreterDiagnosticTest {
 						  "7| str -= ' World!';" + nl() + 
 						  "   ^^^" + nl() + 
 						  "Maybe you want one of the following?" + nlnl() + 
-						  "    self" + nlnl() + 
+						  "    self" + nl() + 
 						  "  At input/diagnostics/removeToVariableUndeclared.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}
@@ -616,7 +612,7 @@ public class InterpreterDiagnosticTest {
 		
 		String expected = "Type mismatch between expected type `ecore::EBoolean` and actual type `java.lang.String`." + nlnl() + 
 						  "7| while ('Hello World!') {" + nl() + 
-						  "          ^^^^^^^^^^^^^^ should be `ecore::EBoolean`" + nlnl() + 
+						  "          ^^^^^^^^^^^^^^ should be `ecore::EBoolean`" + nl() + 
 						  "  At input/diagnostics/whileNonBooleanCondition.ale:7" + nl(); 
 		assertEquals("Wrong output on stderr", expected, getErr());
 	}


### PR DESCRIPTION
Closes https://github.com/gemoc/ale-lang/issues/38

This PR :
- ensures that all the stack is correctly shown on the error log even if there is no underlying diagnostic message (ie. error without message), the stack is shown in the usual direction (deepest on top)
- add a new detection for assignment to unassigned variables or features
- add 4 tests to verify the detection of the  assignment to unassigned variables or features (both at the eval level and the stderr output level)

![image](https://user-images.githubusercontent.com/661468/97026798-2829cc80-155a-11eb-9c58-caca2e6fab1a.png)


## Changes

 - add a new diagnostic `Uninitilaized`  in diagnostic.ecore
 -